### PR TITLE
Fix updater repo URL

### DIFF
--- a/plugin/ff-wc-jcc/ff-wc-jcc.php
+++ b/plugin/ff-wc-jcc/ff-wc-jcc.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/../../plugin-update-checker/plugin-update-checker.php';
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 $ff_wc_jcc_update_checker = PucFactory::buildUpdateChecker(
-    'https://github.com/GeorgeWebDevCy/taxnexcy/',
+    'https://github.com/GeorgeWebDevCy/taxnexcy',
     __FILE__,
     'ff-wc-jcc'
 );


### PR DESCRIPTION
## Summary
- update repo URL for FF_WC_JCC updater

## Testing
- `php -l plugin/ff-wc-jcc/ff-wc-jcc.php`


------
https://chatgpt.com/codex/tasks/task_e_6888c1e5db6083278ba78c869ea92d85