### PR TITLE
Add WordPress readme and bump version

### DIFF
--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -69,8 +69,8 @@ class Taxnexcy {
 	public function __construct() {
 		if ( defined( 'TAXNEXCY_VERSION' ) ) {
 			$this->version = TAXNEXCY_VERSION;
-		} else {
-			$this->version = '1.0.0';
+               } else {
+                       $this->version = '1.0.1';
 		}
 		$this->plugin_name = 'taxnexcy';
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,25 @@
+=== Taxnex Cyprus ===
+Contributors: GeorgeWebDevCy
+Donate link: https://georgenicolaou.me/
+Tags: fluentforms, woocommerce, jcc
+Requires at least: 5.0
+Tested up to: 6.5
+Stable tag: 1.0.1
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and orders and redirects users to JCC for payment.
+
+== Description ==
+This plugin integrates FluentForms with WooCommerce and JCC to create orders and process payments automatically.
+
+== Installation ==
+1. Upload the `taxnexcy` plugin folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+
+== Changelog ==
+= 1.0.1 =
+* Update plugin version.
+
+= 1.0.0 =
+* Initial release.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.0.0' );
+define( 'TAXNEXCY_VERSION', '1.0.1' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## Summary
- add a WordPress `readme.txt`
- bump plugin version to `1.0.1`

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6888dce0b0088327bbc84e751d8bc462