### PR TITLE
Fix update check and bump version

### DIFF
--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -70,7 +70,7 @@ class Taxnexcy {
 		if ( defined( 'TAXNEXCY_VERSION' ) ) {
 			$this->version = TAXNEXCY_VERSION;
                } else {
-                       $this->version = '1.0.1';
+                       $this->version = '1.0.2';
 		}
 		$this->plugin_name = 'taxnexcy';
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,9 @@ This plugin integrates FluentForms with WooCommerce and JCC to create orders and
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+= 1.0.2 =
+* Fix update checker authentication handling.
+
 = 1.0.1 =
 * Update plugin version.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.0.1' );
+define( 'TAXNEXCY_VERSION', '1.0.2' );
 
 /**
  * The code that runs during plugin activation.
@@ -74,6 +74,10 @@ $taxnexcy_update_checker = PucFactory::buildUpdateChecker(
     'taxnexcy'
 );
 $taxnexcy_update_checker->setBranch('main');
+$token = defined('TAXNEXCY_GITHUB_TOKEN') ? TAXNEXCY_GITHUB_TOKEN : getenv('TAXNEXCY_GITHUB_TOKEN');
+if ( ! empty( $token ) ) {
+    $taxnexcy_update_checker->setAuthentication( $token );
+}
 
 /**
  * Begins execution of the plugin.


### PR DESCRIPTION
## Summary
- hook up optional GitHub token for update checking
- bump plugin version to 1.0.2
- document the change in the changelog

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6888de258f88832799942913ab1003e5