### PR TITLE
Add Fluent Forms WooCommerce integration

### DIFF
--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Handle Fluent Forms submissions.
+ *
+ * @package Taxnexcy
+ */
+
+class Taxnexcy_FluentForms {
+
+    /**
+     * Plugin version.
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
+     * Initialize class and set hooks.
+     *
+     * @param string $version Plugin version.
+     */
+    public function __construct( $version ) {
+        $this->version = $version;
+
+        add_action( 'fluentform_submission_inserted', array( $this, 'create_customer_and_order' ), 10, 3 );
+        add_filter( 'fluentform_submission_response', array( $this, 'maybe_redirect_to_payment' ), 10, 3 );
+    }
+
+    /**
+     * Create WooCommerce customer and order when a form is submitted.
+     *
+     * @param int   $entry_id Entry ID.
+     * @param array $form_data Submitted form data.
+     * @param array $form Form settings.
+     */
+    public function create_customer_and_order( $entry_id, $form_data, $form ) {
+        if ( ! function_exists( 'wc_create_new_customer' ) ) {
+            return;
+        }
+
+        $first_name = sanitize_text_field( $form_data['first_name'] ?? '' );
+        $last_name  = sanitize_text_field( $form_data['last_name'] ?? '' );
+        $email      = sanitize_email( $form_data['email'] ?? '' );
+
+        if ( ! $email ) {
+            return;
+        }
+
+        $user_id = email_exists( $email );
+
+        if ( ! $user_id ) {
+            $password = wp_generate_password();
+            $user_id  = wc_create_new_customer( $email, '', $password );
+
+            if ( ! is_wp_error( $user_id ) ) {
+                wp_update_user( array(
+                    'ID'         => $user_id,
+                    'first_name' => $first_name,
+                    'last_name'  => $last_name,
+                ) );
+            } else {
+                $user_id = 0;
+            }
+        }
+
+        if ( ! $user_id ) {
+            return;
+        }
+
+        $product_id = apply_filters( 'taxnexcy_product_id', 0 );
+        $product    = wc_get_product( $product_id );
+
+        if ( ! $product ) {
+            return;
+        }
+
+        $order = wc_create_order( array( 'customer_id' => $user_id ) );
+        $order->add_product( $product, 1 );
+        $order->set_payment_method( 'jccgateway' );
+        $order->calculate_totals();
+
+        update_post_meta( $entry_id, '_taxnexcy_order_id', $order->get_id() );
+    }
+
+    /**
+     * Redirect users to the order payment page after submission.
+     *
+     * @param array $response Original response.
+     * @param array $form_data Form data.
+     * @param array $form Form settings.
+     * @return array
+     */
+    public function maybe_redirect_to_payment( $response, $form_data, $form ) {
+        $entry_id = $form_data['entry_id'] ?? 0;
+        $order_id = $entry_id ? (int) get_post_meta( $entry_id, '_taxnexcy_order_id', true ) : 0;
+
+        if ( $order_id ) {
+            $order   = wc_get_order( $order_id );
+            $url     = $order ? $order->get_checkout_payment_url() : '';
+            if ( $url ) {
+                $response['redirect_to'] = $url;
+            }
+        }
+
+        return $response;
+    }
+}

--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -81,8 +81,8 @@ class Taxnexcy {
 
 	}
 
-	/**
-	 * Load the required dependencies for this plugin.
+/**
+ * Load the required dependencies for this plugin.
 	 *
 	 * Include the following files that make up the plugin:
 	 *
@@ -120,7 +120,12 @@ class Taxnexcy {
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-taxnexcy-public.php';
+require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-taxnexcy-public.php';
+
+/**
+ * Handles Fluent Forms submissions.
+ */
+require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-taxnexcy-fluentforms.php';
 
 		$this->loader = new Taxnexcy_Loader();
 
@@ -168,10 +173,12 @@ class Taxnexcy {
 	 */
 	private function define_public_hooks() {
 
-		$plugin_public = new Taxnexcy_Public( $this->get_plugin_name(), $this->get_version() );
+                $plugin_public = new Taxnexcy_Public( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+
+                $fluentforms = new Taxnexcy_FluentForms( $this->get_version() );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.0.2
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin integrates FluentForms with WooCommerce and JCC to create orders and
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+= 1.1.0 =
+* Create WooCommerce customers and orders from Fluent Forms submissions and redirect users to JCC for payment.
 = 1.0.2 =
 * Fix update checker authentication handling.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.0.2
+ * Version:           1.1.0
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.0.2' );
+define( 'TAXNEXCY_VERSION', '1.1.0' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## Summary
- create a class to handle Fluent Forms submissions
- generate WooCommerce customers and orders on form submission
- redirect customers to the JCC payment page after submission
- bump plugin version to 1.1.0 and document changes

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l includes/class-taxnexcy.php`
- `php -l taxnexcy.php`
- `find . -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6888e0d836c88327b6ed8f12fffa6e7d