### PR TITLE
Store Fluent Forms data in order meta

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,6 +18,8 @@ This plugin integrates FluentForms with WooCommerce and JCC to create orders and
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+= 1.2.0 =
+* Store Fluent Forms submission data in the WooCommerce order and show it in order emails.
 = 1.1.0 =
 * Create WooCommerce customers and orders from Fluent Forms submissions and redirect users to JCC for payment.
 = 1.0.2 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.1.0' );
+define( 'TAXNEXCY_VERSION', '1.2.0' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## Summary
- save Fluent Forms submission fields as order meta
- add those meta fields to WooCommerce emails
- bump plugin version to 1.2.0

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_6888e316d1b08327a8fbdad799d8ea14