### PR TITLE
Fix updater and bump version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.3.1 =
+* Enable GitHub release assets for updates.
 = 1.3.0 =
 * Bump plugin version.
 = 1.2.0 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.3.0
+ * Version:           1.3.1
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.3.0' );
+define( 'TAXNEXCY_VERSION', '1.3.1' );
 
 /**
  * The code that runs during plugin activation.
@@ -74,6 +74,7 @@ $taxnexcy_update_checker = PucFactory::buildUpdateChecker(
     'taxnexcy'
 );
 $taxnexcy_update_checker->setBranch('main');
+$taxnexcy_update_checker->getVcsApi()->enableReleaseAssets();
 $token = defined('TAXNEXCY_GITHUB_TOKEN') ? TAXNEXCY_GITHUB_TOKEN : getenv('TAXNEXCY_GITHUB_TOKEN');
 if ( ! empty( $token ) ) {
     $taxnexcy_update_checker->setAuthentication( $token );


### PR DESCRIPTION
## Summary
- enable release assets in the updater
- bump plugin version to 1.3.1
- document release asset usage in changelog

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6888ebcd701c8327b5580af88889cbae