### PR TITLE
Enable mapping forms to WooCommerce products

### DIFF
--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -77,11 +77,11 @@ class Taxnexcy_FluentForms {
             return;
         }
 
-        $product_id = apply_filters( 'taxnexcy_product_id', 0 );
+        $product_id = apply_filters( 'taxnexcy_product_id', 0, $form, $form_data );
         $product    = wc_get_product( $product_id );
 
         if ( ! $product ) {
-            Taxnexcy_Logger::log( 'Product not found' );
+            Taxnexcy_Logger::log( 'Product not found for form ' . ( $form['id'] ?? 'unknown' ) . ' (ID ' . $product_id . ')' );
             return;
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.5.0 =
+* Map individual FluentForms to specific WooCommerce products using the `TAXNEXCY_FORM_PRODUCTS` constant.
 = 1.4.0 =
 * Add admin log viewer and verbose logging throughout the plugin.
 = 1.3.1 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.4.0
+ * Version:           1.5.0
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,16 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.4.0' );
+define( 'TAXNEXCY_VERSION', '1.5.0' );
+
+/**
+ * Map Fluent Forms IDs to WooCommerce product IDs.
+ * Example:
+ * define( 'TAXNEXCY_FORM_PRODUCTS', array( 10 => 123, 20 => 456 ) );
+ */
+if ( ! defined( 'TAXNEXCY_FORM_PRODUCTS' ) ) {
+    define( 'TAXNEXCY_FORM_PRODUCTS', array() );
+}
 
 /**
  * The code that runs during plugin activation.
@@ -80,6 +89,23 @@ $token = defined('TAXNEXCY_GITHUB_TOKEN') ? TAXNEXCY_GITHUB_TOKEN : getenv('TAXN
 if ( ! empty( $token ) ) {
     $taxnexcy_update_checker->setAuthentication( $token );
 }
+
+/**
+ * Resolve product ID for a given Fluent Forms submission.
+ *
+ * @param int   $default   Default product ID.
+ * @param array $form      Form settings.
+ * @param array $form_data Submitted form data.
+ * @return int Product ID.
+ */
+function taxnexcy_product_mapping( $default, $form, $form_data ) {
+    $form_id = is_array( $form ) && isset( $form['id'] ) ? intval( $form['id'] ) : 0;
+    if ( $form_id && isset( TAXNEXCY_FORM_PRODUCTS[ $form_id ] ) ) {
+        return intval( TAXNEXCY_FORM_PRODUCTS[ $form_id ] );
+    }
+    return $default;
+}
+add_filter( 'taxnexcy_product_id', 'taxnexcy_product_mapping', 10, 3 );
 
 /**
  * Begins execution of the plugin.


### PR DESCRIPTION
## Summary
- allow mapping FluentForms to products via `TAXNEXCY_FORM_PRODUCTS`
- expose product mapping through new `taxnexcy_product_mapping` filter
- log details when a product cannot be resolved
- bump plugin version to 1.5.0 and update documentation

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`
- `find . -name '*.php' -print | xargs -I {} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_688b29aa29788327b6bd62807631233b