### PR TITLE
Add admin mapping menu and update version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 4.3
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/admin/class-taxnexcy-admin.php
+++ b/admin/class-taxnexcy-admin.php
@@ -100,13 +100,31 @@ class Taxnexcy_Admin {
         }
 
         /**
-         * Add the Taxnexcy log page under Tools.
+         * Register Taxnexcy admin menu and subpages.
          */
-        public function add_menu_page() {
+        public function add_admin_menu() {
+                add_menu_page(
+                        'Taxnexcy',
+                        'Taxnexcy',
+                        'manage_options',
+                        'taxnexcy',
+                        array( $this, 'render_settings_page' ),
+                        'dashicons-cart'
+                );
+
                 add_submenu_page(
-                        'tools.php',
-                        'Taxnexcy Log',
-                        'Taxnexcy Log',
+                        'taxnexcy',
+                        'Form Product Mapping',
+                        'Form Product Mapping',
+                        'manage_options',
+                        'taxnexcy',
+                        array( $this, 'render_settings_page' )
+                );
+
+                add_submenu_page(
+                        'taxnexcy',
+                        'Log',
+                        'Log',
                         'manage_options',
                         'taxnexcy-log',
                         array( $this, 'render_log_page' )
@@ -126,6 +144,18 @@ class Taxnexcy_Admin {
         }
 
         /**
+         * Render the settings page.
+         */
+        public function render_settings_page() {
+                if ( ! current_user_can( 'manage_options' ) ) {
+                        return;
+                }
+
+                $mappings = get_option( TAXNEXCY_FORM_PRODUCTS_OPTION, array() );
+                include plugin_dir_path( __FILE__ ) . 'partials/taxnexcy-settings-page.php';
+        }
+
+        /**
          * Handle clearing the log.
          */
         public function handle_clear_log() {
@@ -135,7 +165,34 @@ class Taxnexcy_Admin {
 
                 check_admin_referer( 'taxnexcy_clear_log' );
                 Taxnexcy_Logger::clear();
-                wp_redirect( admin_url( 'tools.php?page=taxnexcy-log' ) );
+                wp_redirect( admin_url( 'admin.php?page=taxnexcy-log' ) );
+                exit;
+        }
+
+        /**
+         * Handle saving form to product mappings.
+         */
+        public function handle_save_mappings() {
+                if ( ! current_user_can( 'manage_options' ) ) {
+                        wp_die( 'Forbidden' );
+                }
+
+                check_admin_referer( 'taxnexcy_save_mappings' );
+
+                $forms    = isset( $_POST['taxnexcy_forms'] ) ? array_map( 'intval', (array) $_POST['taxnexcy_forms'] ) : array();
+                $products = isset( $_POST['taxnexcy_products'] ) ? array_map( 'intval', (array) $_POST['taxnexcy_products'] ) : array();
+
+                $mappings = array();
+                foreach ( $forms as $index => $form_id ) {
+                        $product_id = $products[ $index ] ?? 0;
+                        if ( $form_id && $product_id ) {
+                                $mappings[ $form_id ] = $product_id;
+                        }
+                }
+
+                update_option( TAXNEXCY_FORM_PRODUCTS_OPTION, $mappings );
+
+                wp_redirect( admin_url( 'admin.php?page=taxnexcy' ) );
                 exit;
         }
 

--- a/admin/partials/taxnexcy-settings-page.php
+++ b/admin/partials/taxnexcy-settings-page.php
@@ -1,0 +1,30 @@
+<div class="wrap">
+    <h1><?php esc_html_e( 'Form Product Mapping', 'taxnexcy' ); ?></h1>
+    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+        <?php wp_nonce_field( 'taxnexcy_save_mappings' ); ?>
+        <input type="hidden" name="action" value="taxnexcy_save_mappings" />
+        <table class="widefat">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Form ID', 'taxnexcy' ); ?></th>
+                    <th><?php esc_html_e( 'Product ID', 'taxnexcy' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if ( ! empty( $mappings ) ) : ?>
+                    <?php foreach ( $mappings as $form_id => $product_id ) : ?>
+                        <tr>
+                            <td><input type="number" name="taxnexcy_forms[]" value="<?php echo esc_attr( $form_id ); ?>" class="small-text" /></td>
+                            <td><input type="number" name="taxnexcy_products[]" value="<?php echo esc_attr( $product_id ); ?>" class="small-text" /></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+                <tr>
+                    <td><input type="number" name="taxnexcy_forms[]" class="small-text" /></td>
+                    <td><input type="number" name="taxnexcy_products[]" class="small-text" /></td>
+                </tr>
+            </tbody>
+        </table>
+        <p><button type="submit" class="button button-primary"><?php esc_html_e( 'Save Mappings', 'taxnexcy' ); ?></button></p>
+    </form>
+</div>

--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -161,8 +161,9 @@ require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-taxnexcy-f
 
                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
                $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
-               $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_menu_page' );
+               $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_admin_menu' );
                $this->loader->add_action( 'admin_post_taxnexcy_clear_log', $plugin_admin, 'handle_clear_log' );
+               $this->loader->add_action( 'admin_post_taxnexcy_save_mappings', $plugin_admin, 'handle_save_mappings' );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.5.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,10 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.6.0 =
+* Add admin page to map Fluent Forms to WooCommerce products.
+* Move log viewer under the new Taxnexcy menu.
+* Read mappings from saved options.
 = 1.5.0 =
 * Map individual FluentForms to specific WooCommerce products using the `TAXNEXCY_FORM_PRODUCTS` constant.
 = 1.4.0 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.5.0
+ * Version:           1.6.0
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.5.0' );
+define( 'TAXNEXCY_VERSION', '1.6.0' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -45,6 +45,11 @@ define( 'TAXNEXCY_VERSION', '1.5.0' );
 if ( ! defined( 'TAXNEXCY_FORM_PRODUCTS' ) ) {
     define( 'TAXNEXCY_FORM_PRODUCTS', array() );
 }
+
+/**
+ * Option key used to store form to product mappings.
+ */
+define( 'TAXNEXCY_FORM_PRODUCTS_OPTION', 'taxnexcy_form_products' );
 
 /**
  * The code that runs during plugin activation.
@@ -99,10 +104,17 @@ if ( ! empty( $token ) ) {
  * @return int Product ID.
  */
 function taxnexcy_product_mapping( $default, $form, $form_data ) {
-    $form_id = is_array( $form ) && isset( $form['id'] ) ? intval( $form['id'] ) : 0;
+    $form_id  = is_array( $form ) && isset( $form['id'] ) ? intval( $form['id'] ) : 0;
+    $mappings = get_option( TAXNEXCY_FORM_PRODUCTS_OPTION, array() );
+
+    if ( $form_id && isset( $mappings[ $form_id ] ) ) {
+        return intval( $mappings[ $form_id ] );
+    }
+
     if ( $form_id && isset( TAXNEXCY_FORM_PRODUCTS[ $form_id ] ) ) {
         return intval( TAXNEXCY_FORM_PRODUCTS[ $form_id ] );
     }
+
     return $default;
 }
 add_filter( 'taxnexcy_product_id', 'taxnexcy_product_mapping', 10, 3 );


### PR DESCRIPTION
## Summary
- add a simple Taxnexcy settings page to map forms to products
- move logger under the new Taxnexcy menu
- store mappings in an option and use them when selecting products
- bump version to 1.6.0 and update documentation

## Testing
- `find . -name '*.php' -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_688b2bb31db88327adaf9eec445dd529