### PR TITLE
Show titles in mapping dropdown

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,12 +67,11 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 
 == Changelog ==
 
-= 1.0 =
-* A change since the previous version.
-* Another change.
+= 1.7.0 =
+* Show product and form titles in dropdowns on the mapping page.
 
-= 0.5 =
-* List versions from most recent at top to oldest at bottom.
+= 1.6.0 =
+* Add admin page to map Fluent Forms to WooCommerce products.
 
 == Upgrade Notice ==
 

--- a/admin/class-taxnexcy-admin.php
+++ b/admin/class-taxnexcy-admin.php
@@ -152,6 +152,28 @@ class Taxnexcy_Admin {
                 }
 
                 $mappings = get_option( TAXNEXCY_FORM_PRODUCTS_OPTION, array() );
+
+                $forms = array();
+                if ( class_exists( '\\FluentForm\\App\\Models\\Form' ) ) {
+                        try {
+                                $forms = \FluentForm\App\Models\Form::select( 'id', 'title' )
+                                        ->orderBy( 'title', 'ASC' )
+                                        ->get();
+                        } catch ( Exception $e ) {
+                                $forms = array();
+                        }
+                }
+
+                $products = array();
+                if ( function_exists( 'wc_get_products' ) ) {
+                        $products = wc_get_products( array(
+                                'limit'   => -1,
+                                'status'  => 'publish',
+                                'orderby' => 'title',
+                                'order'   => 'ASC',
+                        ) );
+                }
+
                 include plugin_dir_path( __FILE__ ) . 'partials/taxnexcy-settings-page.php';
         }
 

--- a/admin/partials/taxnexcy-settings-page.php
+++ b/admin/partials/taxnexcy-settings-page.php
@@ -6,22 +6,62 @@
         <table class="widefat">
             <thead>
                 <tr>
-                    <th><?php esc_html_e( 'Form ID', 'taxnexcy' ); ?></th>
-                    <th><?php esc_html_e( 'Product ID', 'taxnexcy' ); ?></th>
+                    <th><?php esc_html_e( 'Form', 'taxnexcy' ); ?></th>
+                    <th><?php esc_html_e( 'Product', 'taxnexcy' ); ?></th>
                 </tr>
             </thead>
             <tbody>
                 <?php if ( ! empty( $mappings ) ) : ?>
                     <?php foreach ( $mappings as $form_id => $product_id ) : ?>
                         <tr>
-                            <td><input type="number" name="taxnexcy_forms[]" value="<?php echo esc_attr( $form_id ); ?>" class="small-text" /></td>
-                            <td><input type="number" name="taxnexcy_products[]" value="<?php echo esc_attr( $product_id ); ?>" class="small-text" /></td>
+                            <td>
+                                <select name="taxnexcy_forms[]">
+                                    <option value=""><?php esc_html_e( 'Select form', 'taxnexcy' ); ?></option>
+                                    <?php foreach ( $forms as $form ) : ?>
+                                        <?php $fid = is_object( $form ) ? $form->id : $form['id']; ?>
+                                        <option value="<?php echo esc_attr( $fid ); ?>" <?php selected( $form_id, $fid ); ?>>
+                                            <?php echo esc_html( is_object( $form ) ? $form->title : $form['title'] ); ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </td>
+                            <td>
+                                <select name="taxnexcy_products[]">
+                                    <option value=""><?php esc_html_e( 'Select product', 'taxnexcy' ); ?></option>
+                                    <?php foreach ( $products as $product ) : ?>
+                                        <?php $pid = is_object( $product ) ? $product->get_id() : $product['ID']; ?>
+                                        <option value="<?php echo esc_attr( $pid ); ?>" <?php selected( $product_id, $pid ); ?>>
+                                            <?php echo esc_html( is_object( $product ) ? $product->get_name() : $product['post_title'] ); ?>
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </td>
                         </tr>
                     <?php endforeach; ?>
                 <?php endif; ?>
                 <tr>
-                    <td><input type="number" name="taxnexcy_forms[]" class="small-text" /></td>
-                    <td><input type="number" name="taxnexcy_products[]" class="small-text" /></td>
+                    <td>
+                        <select name="taxnexcy_forms[]">
+                            <option value=""><?php esc_html_e( 'Select form', 'taxnexcy' ); ?></option>
+                            <?php foreach ( $forms as $form ) : ?>
+                                <?php $fid = is_object( $form ) ? $form->id : $form['id']; ?>
+                                <option value="<?php echo esc_attr( $fid ); ?>">
+                                    <?php echo esc_html( is_object( $form ) ? $form->title : $form['title'] ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                    <td>
+                        <select name="taxnexcy_products[]">
+                            <option value=""><?php esc_html_e( 'Select product', 'taxnexcy' ); ?></option>
+                            <?php foreach ( $products as $product ) : ?>
+                                <?php $pid = is_object( $product ) ? $product->get_id() : $product['ID']; ?>
+                                <option value="<?php echo esc_attr( $pid ); ?>">
+                                    <?php echo esc_html( is_object( $product ) ? $product->get_name() : $product['post_title'] ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
                 </tr>
             </tbody>
         </table>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.0 =
+* Show product and form titles in dropdowns on the mapping page.
 = 1.6.0 =
 * Add admin page to map Fluent Forms to WooCommerce products.
 * Move log viewer under the new Taxnexcy menu.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.6.0
+ * Version:           1.7.0
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.6.0' );
+define( 'TAXNEXCY_VERSION', '1.7.0' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- show forms and products in dropdowns instead of ID inputs
- fetch available forms and products for settings page
- bump plugin version to 1.7.0
- document changes in readme files

## Testing
- `php -l admin/partials/taxnexcy-settings-page.php`
- `php -l admin/class-taxnexcy-admin.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688b2e1408e08327a1502270b58a76a5