### PR TITLE
Fix form mapping bug and bump version to 1.7.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.7.1 =
+* Fix form ID detection when Fluent Forms passes objects.
 
 = 1.7.0 =
 * Show product and form titles in dropdowns on the mapping page.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.1 =
+* Fix form ID detection when Fluent Forms passes objects.
 = 1.7.0 =
 * Show product and form titles in dropdowns on the mapping page.
 = 1.6.0 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.0
+ * Version:           1.7.1
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.0' );
+define( 'TAXNEXCY_VERSION', '1.7.1' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -104,7 +104,13 @@ if ( ! empty( $token ) ) {
  * @return int Product ID.
  */
 function taxnexcy_product_mapping( $default, $form, $form_data ) {
-    $form_id  = is_array( $form ) && isset( $form['id'] ) ? intval( $form['id'] ) : 0;
+    if ( is_array( $form ) && isset( $form['id'] ) ) {
+        $form_id = intval( $form['id'] );
+    } elseif ( is_object( $form ) && isset( $form->id ) ) {
+        $form_id = intval( $form->id );
+    } else {
+        $form_id = 0;
+    }
     $mappings = get_option( TAXNEXCY_FORM_PRODUCTS_OPTION, array() );
 
     if ( $form_id && isset( $mappings[ $form_id ] ) ) {


### PR DESCRIPTION
## Summary
- fix product mapping when Fluent Forms provides the form as an object
- bump plugin version to 1.7.1
- document changes in readme files

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688b30c009e48327bc12cacddc48e8af