### PR TITLE
Store FluentForms answers on orders

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.7.2 =
+* Store Fluent Forms answers in WooCommerce orders and show them in admin and emails.
 
 = 1.7.1 =
 * Fix form ID detection when Fluent Forms passes objects.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -26,6 +26,7 @@ class Taxnexcy_FluentForms {
         add_action( 'fluentform_submission_inserted', array( $this, 'create_customer_and_order' ), 10, 3 );
         add_filter( 'fluentform_submission_response', array( $this, 'maybe_redirect_to_payment' ), 10, 3 );
         add_filter( 'woocommerce_email_order_meta_fields', array( $this, 'add_email_meta_fields' ), 10, 3 );
+        add_action( 'woocommerce_admin_order_data_after_order_details', array( $this, 'display_admin_meta_fields' ) );
     }
 
     /**
@@ -150,5 +151,22 @@ class Taxnexcy_FluentForms {
         }
 
         return $fields;
+    }
+
+    /**
+     * Display Fluent Forms data in the WooCommerce admin order screen.
+     *
+     * @param WC_Order $order The order object.
+     */
+    public function display_admin_meta_fields( $order ) {
+        echo '<div class="order_data_column">';
+        echo '<h4>' . esc_html__( 'Fluent Forms Answers', 'taxnexcy' ) . '</h4>';
+        foreach ( $order->get_meta_data() as $meta ) {
+            if ( strpos( $meta->key, 'taxnexcy_' ) === 0 ) {
+                $label = ucwords( str_replace( '_', ' ', substr( $meta->key, 9 ) ) );
+                printf( '<p><strong>%s:</strong> %s</p>', esc_html( $label ), esc_html( $meta->value ) );
+            }
+        }
+        echo '</div>';
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.2 =
+* Store Fluent Forms answers in WooCommerce orders and show them in admin and emails.
 = 1.7.1 =
 * Fix form ID detection when Fluent Forms passes objects.
 = 1.7.0 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.1
+ * Version:           1.7.2
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.1' );
+define( 'TAXNEXCY_VERSION', '1.7.2' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- show stored FluentForms answers in WooCommerce orders
- bump plugin version to 1.7.2

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688b35cbaec0832794b614d9190d1fb8