### PR TITLE
Display Fluent Forms data in tables

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.4
+Stable tag: 1.7.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.5 =
+* Display Fluent Forms answers as a table in WooCommerce emails and the admin order screen.
 = 1.7.4 =
 * Fix storing form questions and answers in order meta.
 = 1.7.3 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.4
+ * Version:           1.7.5
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.4' );
+define( 'TAXNEXCY_VERSION', '1.7.5' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- show form questions & answers in tables in order admin and emails
- add helper to collect Fluent Forms answers
- bump version to 1.7.5 and update readme

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`

------
https://chatgpt.com/codex/tasks/task_e_688b42c09efc83279b05b442e6923b8a