### PR TITLE
Handle array field values and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.6
+Stable tag: 1.7.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.7.7 =
+* Handle array values from Fluent Forms submissions when storing order meta.
 
 = 1.7.6 =
 * Skip internal Fluent Forms fields and use stored question labels when displaying order data.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -104,10 +104,6 @@ class Taxnexcy_FluentForms {
         }
 
         foreach ( $form_data as $key => $value ) {
-            if ( ! is_scalar( $value ) ) {
-                continue;
-            }
-
             $sanitized_key = sanitize_key( $key );
 
             // Skip internal Fluent Forms fields like nonces or referrers.
@@ -116,7 +112,13 @@ class Taxnexcy_FluentForms {
                 continue;
             }
 
-            $order->update_meta_data( 'taxnexcy_' . $sanitized_key, sanitize_text_field( $value ) );
+            if ( is_array( $value ) ) {
+                $value = implode( ', ', array_map( 'sanitize_text_field', $value ) );
+            } else {
+                $value = sanitize_text_field( $value );
+            }
+
+            $order->update_meta_data( 'taxnexcy_' . $sanitized_key, $value );
 
             if ( isset( $labels[ $sanitized_key ] ) ) {
                 $order->update_meta_data( 'taxnexcy_label_' . $sanitized_key, $labels[ $sanitized_key ] );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.6
+Stable tag: 1.7.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.7 =
+* Handle array values from Fluent Forms submissions when storing order meta.
+
 = 1.7.6 =
 * Skip internal Fluent Forms fields and use stored question labels when displaying order data.
 = 1.7.5 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.6
+ * Version:           1.7.7
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.6' );
+define( 'TAXNEXCY_VERSION', '1.7.7' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- support array values from Fluent Forms when creating order meta
- bump plugin version to 1.7.7
- document update in changelog

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688b4ff3f43883279b7be9422371f30e