### PR TITLE
Add logging for order fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: comments, spam
 Requires at least: 3.0.1
 Tested up to: 3.4
-Stable tag: 1.7.9
+Stable tag: 1.7.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
+
+= 1.7.10 =
+* Log saved order fields for debugging question order issues.
 
 = 1.7.9 =
 * Log raw Fluent Forms submission data for debugging.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -129,6 +129,10 @@ class Taxnexcy_FluentForms {
         $order->save();
         Taxnexcy_Logger::log( 'Order ' . $order->get_id() . ' saved' );
 
+        // Log the saved question/answer pairs for debugging order issues.
+        $debug_fields = $this->get_ff_fields( $order );
+        Taxnexcy_Logger::log( 'Saved order fields: ' . wp_json_encode( $debug_fields ) );
+
         update_post_meta( $entry_id, '_taxnexcy_order_id', $order->get_id() );
         Taxnexcy_Logger::log( 'Stored order ID in entry meta' );
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.9
+Stable tag: 1.7.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.10 =
+* Log saved order fields for debugging question order issues.
 = 1.7.9 =
 * Log raw Fluent Forms submission data for debugging.
 = 1.7.8 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.9
+ * Version:           1.7.10
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.9' );
+define( 'TAXNEXCY_VERSION', '1.7.10' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log saved question/answer pairs from FluentForm submissions
- bump plugin version to 1.7.10

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688bc544a73083279dae361ef3b60cf9