### PR TITLE
Use admin field labels for form question text

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.13
+Stable tag: 1.7.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.14 =
+* Use admin field labels from Fluent Forms for saved question text.
 = 1.7.13 =
 * Document how question/answer order comes from Fluent Forms {all_data}.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -1,4 +1,5 @@
 <?php
+use FluentForm\App\Modules\Form\FormFieldsParser;
 /**
  * Handle Fluent Forms submissions.
  *
@@ -95,10 +96,14 @@ class Taxnexcy_FluentForms {
         $order->calculate_totals();
 
         $labels = array();
-        if ( isset( $form['fields'] ) && is_array( $form['fields'] ) ) {
+        if ( class_exists( '\\FluentForm\\App\\Modules\\Form\\FormFieldsParser' ) ) {
+            $form_object = (object) $form;
+            $labels      = FormFieldsParser::getAdminLabels( $form_object, array() );
+        } elseif ( isset( $form['fields'] ) && is_array( $form['fields'] ) ) {
             foreach ( $form['fields'] as $field ) {
                 $name  = sanitize_key( $field['name'] ?? ( $field['attributes']['name'] ?? '' ) );
-                $label = $field['settings']['label'] ?? ( $field['label'] ?? '' );
+                $label = $field['settings']['admin_field_label']
+                    ?: ( $field['settings']['label'] ?? ( $field['label'] ?? '' ) );
                 if ( $name ) {
                     $labels[ $name ] = sanitize_text_field( $label );
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.13
+Stable tag: 1.7.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.14 =
+* Use admin field labels from Fluent Forms for saved question text.
 = 1.7.13 =
 * Document how question/answer order comes from Fluent Forms {all_data}.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.13
+ * Version:           1.7.14
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.13' );
+define( 'TAXNEXCY_VERSION', '1.7.14' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- leverage Fluent Forms' `FormFieldsParser` to get admin labels
- store question text using the admin labels
- bump plugin version to 1.7.14

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688bddb9e1dc8327b97a1d7ab1530cd0