### PR TITLE
Improve logging for JCC redirect and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.14
+Stable tag: 1.7.15
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.15 =
+* Add detailed logging for payment redirect issues.
 = 1.7.14 =
 * Use admin field labels from Fluent Forms for saved question text.
 = 1.7.13 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -151,19 +151,32 @@ class Taxnexcy_FluentForms {
      * @return array
      */
     public function maybe_redirect_to_payment( $response, $form_data, $form ) {
+        Taxnexcy_Logger::log( 'maybe_redirect_to_payment triggered. Raw data: ' . wp_json_encode( $form_data ) );
+
         $entry_id = $form_data['entry_id'] ?? 0;
         $order_id = $entry_id ? (int) get_post_meta( $entry_id, '_taxnexcy_order_id', true ) : 0;
 
+        Taxnexcy_Logger::log( 'Checking redirect for entry ' . $entry_id . ' with order ID ' . $order_id );
+
         if ( $order_id ) {
-            $order   = wc_get_order( $order_id );
-            $url     = $order ? $order->get_checkout_payment_url() : '';
-            if ( $url ) {
-                $response['redirect_to'] = $url;
-                Taxnexcy_Logger::log( 'Redirecting to payment page for order ' . $order_id );
+            $order = wc_get_order( $order_id );
+            if ( $order ) {
+                $url = $order->get_checkout_payment_url();
+                Taxnexcy_Logger::log( 'Checkout URL: ' . $url );
+                if ( $url ) {
+                    $response['redirect_to'] = $url;
+                    Taxnexcy_Logger::log( 'Redirecting to payment page for order ' . $order_id );
+                } else {
+                    Taxnexcy_Logger::log( 'Checkout URL empty for order ' . $order_id );
+                }
+            } else {
+                Taxnexcy_Logger::log( 'Could not load order ' . $order_id );
             }
         } else {
             Taxnexcy_Logger::log( 'No order found for entry ' . $entry_id );
         }
+
+        Taxnexcy_Logger::log( 'Response after redirect check: ' . wp_json_encode( $response ) );
 
         return $response;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.14
+Stable tag: 1.7.15
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.15 =
+* Add detailed logging for payment redirect issues.
 = 1.7.14 =
 * Use admin field labels from Fluent Forms for saved question text.
 = 1.7.13 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.14
+ * Version:           1.7.15
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.14' );
+define( 'TAXNEXCY_VERSION', '1.7.15' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- add verbose logging in `maybe_redirect_to_payment`
- bump plugin version to 1.7.15
- document new version in readme files

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`

------
https://chatgpt.com/codex/tasks/task_e_688bdfa5d8b0832783b0657490437f2d