### PR TITLE
Fix gateway detection and update version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.15
+Stable tag: 1.7.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.16 =
+* Detect available payment gateways and fall back if JCC is missing.
 = 1.7.15 =
 * Add detailed logging for payment redirect issues.
 = 1.7.14 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -92,7 +92,19 @@ class Taxnexcy_FluentForms {
         $order = wc_create_order( array( 'customer_id' => $user_id ) );
         Taxnexcy_Logger::log( 'Created order ' . $order->get_id() . ' for user ' . $user_id );
         $order->add_product( $product, 1 );
-        $order->set_payment_method( 'jccgateway' );
+
+        $available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+        if ( isset( $available_gateways['jccgateway'] ) ) {
+            $order->set_payment_method( 'jccgateway' );
+            Taxnexcy_Logger::log( 'JCC gateway detected and set as payment method' );
+        } elseif ( $available_gateways ) {
+            $fallback = key( $available_gateways );
+            $order->set_payment_method( $fallback );
+            Taxnexcy_Logger::log( 'JCC gateway not available, using ' . $fallback . ' as fallback' );
+        } else {
+            Taxnexcy_Logger::log( 'No payment gateways available' );
+        }
+
         $order->calculate_totals();
 
         $labels = array();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.15
+Stable tag: 1.7.16
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.16 =
+* Detect available payment gateways and fall back if JCC is missing.
 = 1.7.15 =
 * Add detailed logging for payment redirect issues.
 = 1.7.14 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.15
+ * Version:           1.7.16
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.15' );
+define( 'TAXNEXCY_VERSION', '1.7.16' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- handle fallback payment gateways if JCC isn't installed
- bump version to 1.7.16

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`

------
https://chatgpt.com/codex/tasks/task_e_688be202122c8327910f138e723eea67