### PR TITLE
Disable automatic payment redirect

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.16
+Stable tag: 1.7.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.17 =
+* Add option to disable the automatic payment redirect with `TAXNEXCY_DISABLE_REDIRECT`.
 = 1.7.16 =
 * Detect available payment gateways and fall back if JCC is missing.
 = 1.7.15 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -175,9 +175,14 @@ class Taxnexcy_FluentForms {
             if ( $order ) {
                 $url = $order->get_checkout_payment_url();
                 Taxnexcy_Logger::log( 'Checkout URL: ' . $url );
-                if ( $url ) {
+                $should_redirect = ! ( defined( 'TAXNEXCY_DISABLE_REDIRECT' ) && TAXNEXCY_DISABLE_REDIRECT );
+                $should_redirect = apply_filters( 'taxnexcy_redirect_to_payment', $should_redirect, $order_id );
+
+                if ( $url && $should_redirect ) {
                     $response['redirect_to'] = $url;
                     Taxnexcy_Logger::log( 'Redirecting to payment page for order ' . $order_id );
+                } elseif ( ! $should_redirect ) {
+                    Taxnexcy_Logger::log( 'Redirect disabled for order ' . $order_id );
                 } else {
                     Taxnexcy_Logger::log( 'Checkout URL empty for order ' . $order_id );
                 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.16
+Stable tag: 1.7.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.17 =
+* Add option to disable the automatic payment redirect with `TAXNEXCY_DISABLE_REDIRECT`.
 = 1.7.16 =
 * Detect available payment gateways and fall back if JCC is missing.
 = 1.7.15 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.16
+ * Version:           1.7.17
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.16' );
+define( 'TAXNEXCY_VERSION', '1.7.17' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -50,6 +50,14 @@ if ( ! defined( 'TAXNEXCY_FORM_PRODUCTS' ) ) {
  * Option key used to store form to product mappings.
  */
 define( 'TAXNEXCY_FORM_PRODUCTS_OPTION', 'taxnexcy_form_products' );
+
+/**
+ * Disable automatic redirect to the payment page after form submission.
+ * Define TAXNEXCY_DISABLE_REDIRECT as true in wp-config.php to keep users on the form page.
+ */
+if ( ! defined( 'TAXNEXCY_DISABLE_REDIRECT' ) ) {
+    define( 'TAXNEXCY_DISABLE_REDIRECT', false );
+}
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## Summary
- make redirect after Fluent Form submission optional via `TAXNEXCY_DISABLE_REDIRECT`
- bump version to 1.7.17

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_688be43560c88327a2b7b104f699b21b