### PR TITLE
Update docs and support redirect host override

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.18
+Stable tag: 1.7.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,7 +28,15 @@ Define the token in your `wp-config.php` file:
 
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
+You can update the plugin from the command line with:
+
+`wp plugin update taxnexcy`
+
+Set `FLUENT_FORMS_URL` if your WordPress and Fluent Forms sites are on different domains. This host will be used for the payment redirect.
+
 == Changelog ==
+= 1.7.19 =
+* Document WP-CLI update command and `FLUENT_FORMS_URL` environment variable.
 = 1.7.18 =
 * Log when the redirect filter is registered and support alternate Fluent Forms hook.
 = 1.7.17 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -177,7 +177,13 @@ class Taxnexcy_FluentForms {
             $order = wc_get_order( $order_id );
             if ( $order ) {
                 $url = $order->get_checkout_payment_url();
-                Taxnexcy_Logger::log( 'Checkout URL: ' . $url );
+                $override = getenv( 'FLUENT_FORMS_URL' );
+                if ( $override ) {
+                    $url = str_replace( home_url(), rtrim( $override, '/' ), $url );
+                    Taxnexcy_Logger::log( 'Checkout URL overridden via FLUENT_FORMS_URL: ' . $url );
+                } else {
+                    Taxnexcy_Logger::log( 'Checkout URL: ' . $url );
+                }
                 $should_redirect = ! ( defined( 'TAXNEXCY_DISABLE_REDIRECT' ) && TAXNEXCY_DISABLE_REDIRECT );
                 $should_redirect = apply_filters( 'taxnexcy_redirect_to_payment', $should_redirect, $order_id );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.18
+Stable tag: 1.7.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,7 +28,15 @@ Define the token in your `wp-config.php` file:
 
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
+You can update the plugin from the command line with:
+
+`wp plugin update taxnexcy`
+
+Set `FLUENT_FORMS_URL` if your WordPress and Fluent Forms installations use different domains. This value will replace the site host for payment redirects.
+
 == Changelog ==
+= 1.7.19 =
+* Document WP-CLI update command and `FLUENT_FORMS_URL` environment variable.
 = 1.7.18 =
 * Log when the redirect filter is registered and support alternate Fluent Forms hook.
 = 1.7.17 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.18
+ * Version:           1.7.19
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.18' );
+define( 'TAXNEXCY_VERSION', '1.7.19' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- document WP-CLI plugin update command and FLUENT_FORMS_URL
- override redirect host using FLUENT_FORMS_URL
- bump plugin version to 1.7.19

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`

------
https://chatgpt.com/codex/tasks/task_e_688bea274fb8832780928a94bba96438