### PR TITLE
Add logging for payment URL and improve redirection

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.18
+Stable tag: 1.7.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.19 =
+* Log the payment URL when creating an order and ensure Fluent Forms receives a redirect URL.
+
 = 1.7.18 =
 * Log when the redirect filter is registered and support alternate Fluent Forms hook.
 = 1.7.17 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -149,6 +149,10 @@ class Taxnexcy_FluentForms {
         $order->save();
         Taxnexcy_Logger::log( 'Order ' . $order->get_id() . ' saved' );
 
+        // Log the checkout URL for debugging how it is constructed.
+        $payment_url = $order->get_checkout_payment_url();
+        Taxnexcy_Logger::log( 'Generated payment URL: ' . $payment_url );
+
         // Log the saved question/answer pairs for debugging order issues.
         $debug_fields = $this->get_ff_fields( $order );
         Taxnexcy_Logger::log( 'Saved order fields: ' . wp_json_encode( $debug_fields ) );
@@ -182,7 +186,10 @@ class Taxnexcy_FluentForms {
                 $should_redirect = apply_filters( 'taxnexcy_redirect_to_payment', $should_redirect, $order_id );
 
                 if ( $url && $should_redirect ) {
+                    // Provide multiple keys for compatibility with different Fluent Forms versions.
                     $response['redirect_to'] = $url;
+                    $response['redirect_url'] = $url;
+                    $response['redirectTo']    = $url;
                     Taxnexcy_Logger::log( 'Redirecting to payment page for order ' . $order_id );
                 } elseif ( ! $should_redirect ) {
                     Taxnexcy_Logger::log( 'Redirect disabled for order ' . $order_id );

--- a/public/js/taxnexcy-public.js
+++ b/public/js/taxnexcy-public.js
@@ -1,5 +1,17 @@
 (function( $ ) {
-	'use strict';
+        'use strict';
+
+        // Redirect to the payment page if the form response includes a URL.
+        $( document ).on( 'fluentform_submission_success', function( event, data, response ) {
+            var url = '';
+            if ( response ) {
+                url = response.redirect_to || response.redirect_url || response.redirectTo;
+            }
+
+            if ( url ) {
+                window.location.href = url;
+            }
+        } );
 
 	/**
 	 * All of the code for your public-facing JavaScript source

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.18
+Stable tag: 1.7.19
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.19 =
+* Log the payment URL when creating an order and ensure Fluent Forms receives a redirect URL.
+
 = 1.7.18 =
 * Log when the redirect filter is registered and support alternate Fluent Forms hook.
 = 1.7.17 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.18
+ * Version:           1.7.19
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.18' );
+define( 'TAXNEXCY_VERSION', '1.7.19' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log generated payment URL after order creation
- return multiple redirect keys for Fluent Forms
- add JS fallback to handle redirect
- bump version to 1.7.19

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688bec50ddc88327912e8c2b56158336