### PR TITLE
Redirect logged-in users to checkout and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.21
+Stable tag: 1.7.22
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.22 =
+* Redirect logged-in users straight to checkout after form submission.
 = 1.7.21 =
 * Fix redirect and auto login issues on newer Fluent Forms versions.
 = 1.7.20 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -204,6 +204,10 @@ class Taxnexcy_FluentForms {
                     $response['redirect_to'] = $url;
                     $response['redirect_url'] = $url;
                     $response['redirectTo']    = $url;
+                    if ( ! wp_doing_ajax() ) {
+                        wp_safe_redirect( $url );
+                        exit;
+                    }
                     Taxnexcy_Logger::log( 'Redirecting to payment page for order ' . $order_id );
                 } elseif ( ! $should_redirect ) {
                     Taxnexcy_Logger::log( 'Redirect disabled for order ' . $order_id );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.21
+Stable tag: 1.7.22
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.22 =
+* Redirect logged-in users straight to checkout after form submission.
 = 1.7.21 =
 * Fix redirect and auto login issues on newer Fluent Forms versions.
 = 1.7.20 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.21
+ * Version:           1.7.22
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.21' );
+define( 'TAXNEXCY_VERSION', '1.7.22' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Redirect logged-in users straight to the checkout page after form submission.
- Bump plugin version and changelog for 1.7.22.

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688de0387d288327ae0132a777c9ca25