### PR TITLE
Stop creating orders and redirect directly to checkout

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,14 +4,14 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.23
+ Stable tag: 1.7.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and orders and redirects users to JCC for payment.
+Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and redirects users to checkout for payment.
 
 == Description ==
-This plugin integrates FluentForms with WooCommerce and JCC to create orders and process payments automatically.
+This plugin integrates FluentForms with WooCommerce to create customers and process payments automatically.
 
 == Installation ==
 1. Upload the `taxnexcy` plugin folder to the `/wp-content/plugins/` directory.
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.24 =
+* Create customers without generating orders and redirect directly to checkout.
+
 = 1.7.23 =
 * Redirect users to checkout with `add-to-cart` and `quantity` query parameters.
 = 1.7.22 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,14 +4,14 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.23
+ Stable tag: 1.7.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and orders and redirects users to JCC for payment.
+Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and redirects users to checkout for payment.
 
 == Description ==
-This plugin integrates FluentForms with WooCommerce and JCC to create orders and process payments automatically.
+This plugin integrates FluentForms with WooCommerce to create customers and process payments automatically.
 
 == Installation ==
 1. Upload the `taxnexcy` plugin folder to the `/wp-content/plugins/` directory.
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.24 =
+* Create customers without generating orders and redirect directly to checkout.
+
 = 1.7.23 =
 * Redirect users to checkout with `add-to-cart` and `quantity` query parameters.
 = 1.7.22 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -15,8 +15,8 @@
  * @wordpress-plugin
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
- * Description:       Creates WooCommerce user and order from FluentForms submission and redirects to JCC payment
- * Version:           1.7.23
+ * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
+ * Version:           1.7.24
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.23' );
+define( 'TAXNEXCY_VERSION', '1.7.24' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Avoid WooCommerce order creation on FluentForms submission
- Redirect users to checkout without a payment link
- Bump plugin version to 1.7.24 and update docs

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_688dfb60cc0c8327a8e685d1754dbb65