### PR TITLE
Remove pay/cancel order buttons and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.24
+ Stable tag: 1.7.25
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.25 =
+* Remove pay and cancel order buttons from customer order views.
+
 = 1.7.24 =
 * Create customers without generating orders and redirect directly to checkout.
 

--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -180,6 +180,9 @@ require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-taxnexcy-f
 
                 $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
                 $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_filter( 'woocommerce_my_account_my_orders_actions', $plugin_public, 'remove_my_account_order_actions', 10, 2 );
+                $this->loader->add_filter( 'woocommerce_valid_order_statuses_for_payment', $plugin_public, 'disable_order_pay_button', 10, 2 );
+                $this->loader->add_filter( 'woocommerce_valid_order_statuses_for_cancel', $plugin_public, 'disable_order_cancel_button', 10, 2 );
 
                 $fluentforms = new Taxnexcy_FluentForms( $this->get_version() );
 

--- a/public/class-taxnexcy-public.php
+++ b/public/class-taxnexcy-public.php
@@ -82,7 +82,7 @@ class Taxnexcy_Public {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_scripts() {
+public function enqueue_scripts() {
 
 		/**
 		 * This function is provided for demonstration purposes only.
@@ -96,8 +96,43 @@ class Taxnexcy_Public {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy-public.js', array( 'jquery' ), $this->version, false );
+wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy-public.js', array( 'jquery' ), $this->version, false );
 
-	}
+}
+
+       /**
+        * Remove pay and cancel buttons from the My Account orders table.
+        *
+        * @param array    $actions Existing order actions.
+        * @param WC_Order $order   The order object.
+        * @return array Modified order actions.
+        */
+       public function remove_my_account_order_actions( $actions, $order ) {
+               unset( $actions['pay'] );
+               unset( $actions['cancel'] );
+               return $actions;
+       }
+
+       /**
+        * Disable the pay button on the order view page.
+        *
+        * @param array    $statuses Allowed statuses for payment.
+        * @param WC_Order $order    Order object.
+        * @return array
+        */
+       public function disable_order_pay_button( $statuses, $order ) {
+               return array();
+       }
+
+       /**
+        * Disable the cancel button on the order view page.
+        *
+        * @param array    $statuses Allowed statuses for cancellation.
+        * @param WC_Order $order    Order object.
+        * @return array
+        */
+       public function disable_order_cancel_button( $statuses, $order ) {
+               return array();
+       }
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.24
+ Stable tag: 1.7.25
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.25 =
+* Remove pay and cancel order buttons from customer order views.
+
 = 1.7.24 =
 * Create customers without generating orders and redirect directly to checkout.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.24
+ * Version:           1.7.25
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.24' );
+define( 'TAXNEXCY_VERSION', '1.7.25' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- hide pay and cancel actions from WooCommerce order views
- bump plugin version to 1.7.25 and update readme

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy.php`
- `php -l public/class-taxnexcy-public.php`


------
https://chatgpt.com/codex/tasks/task_e_688dfd8a0354832788164863d9d711ab