### PR TITLE
Skip internal Fluent Forms fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.26
+ Stable tag: 1.7.27
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.27 =
+* Skip internal Fluent Forms fields like the nonce, embed post ID and referer.
+
 = 1.7.26 =
 * Store Fluent Forms questions and answers in WooCommerce orders and email them as a table.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -43,7 +43,17 @@ class Taxnexcy_FluentForms {
      */
     public function create_customer( $entry_id, $form_data, $form ) {
         Taxnexcy_Logger::log( 'Processing submission entry ' . $entry_id );
-        Taxnexcy_Logger::log( 'Submission data: ' . wp_json_encode( $form_data ) );
+
+        $log_data   = $form_data;
+        $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id' );
+        foreach ( $log_data as $key => $value ) {
+            $sanitized_key = sanitize_key( $key );
+            if ( in_array( $sanitized_key, $skip_fields, true ) || preg_match( '/^fluentform_\d+_fluentformnonce$/', $sanitized_key ) ) {
+                unset( $log_data[ $key ] );
+            }
+        }
+
+        Taxnexcy_Logger::log( 'Submission data: ' . wp_json_encode( $log_data ) );
         Taxnexcy_Logger::log( 'Form settings: ' . wp_json_encode( $form ) );
         if ( ! function_exists( 'wc_create_new_customer' ) ) {
             Taxnexcy_Logger::log( 'WooCommerce functions unavailable' );
@@ -115,7 +125,7 @@ class Taxnexcy_FluentForms {
             $sanitized_key = sanitize_key( $key );
 
             // Skip internal Fluent Forms fields like nonces or referrers.
-            $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer' );
+            $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id' );
             if ( in_array( $sanitized_key, $skip_fields, true ) || preg_match( '/^fluentform_\d+_fluentformnonce$/', $sanitized_key ) ) {
                 continue;
             }
@@ -234,7 +244,7 @@ class Taxnexcy_FluentForms {
             $label = $order->get_meta( 'taxnexcy_label_' . $slug, true );
 
             // Skip common hidden Fluent Forms fields.
-            if ( in_array( $slug, array( 'wp_http_referer', 'fluentform_nonce', 'fluentform_id' ), true ) ||
+            if ( in_array( $slug, array( 'wp_http_referer', 'fluentform_nonce', 'fluentform_id', 'fluentform_embed_post_id' ), true ) ||
                 preg_match( '/^fluentform_\d+_fluentformnonce$/', $slug ) ) {
                 continue;
             }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.26
+ Stable tag: 1.7.27
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.27 =
+* Skip internal Fluent Forms fields like the nonce, embed post ID and referer.
+
 = 1.7.26 =
 * Store Fluent Forms questions and answers in WooCommerce orders and email them as a table.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.26
+ * Version:           1.7.27
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.26' );
+define( 'TAXNEXCY_VERSION', '1.7.27' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Skip storing and logging internal Fluent Forms fields like nonce, embed post ID, and referrer
- Bump plugin version to 1.7.27

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_688e02ff7f7c8327bcf6b0d6e552dde0