### PR TITLE
Use admin labels for repeater values

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.28
+ Stable tag: 1.7.29
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.29 =
+* Use admin labels when formatting repeater field values.
+
 = 1.7.28 =
 * Display values from Fluent Forms repeater fields in WooCommerce emails.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -42,16 +42,18 @@ class Taxnexcy_FluentForms {
      * nested values into a readable string so they can be displayed in emails
      * and the admin screens.
      *
-     * @param mixed $value Field value.
+     * @param mixed $value  Field value.
+     * @param array $labels Optional field labels indexed by field slug.
      * @return string Sanitized value.
      */
-    private function sanitize_field_value( $value ) {
+    private function sanitize_field_value( $value, $labels = array() ) {
         if ( is_array( $value ) ) {
             $sanitized = array();
             foreach ( $value as $key => $sub_value ) {
-                $sub_value = $this->sanitize_field_value( $sub_value );
+                $sub_value = $this->sanitize_field_value( $sub_value, $labels );
                 if ( is_string( $key ) && $key !== '' && ! is_numeric( $key ) ) {
-                    $sanitized[] = sanitize_text_field( $key ) . ': ' . $sub_value;
+                    $label       = isset( $labels[ $key ] ) ? $labels[ $key ] : $key;
+                    $sanitized[] = sanitize_text_field( $label ) . ': ' . $sub_value;
                 } else {
                     $sanitized[] = $sub_value;
                 }
@@ -158,7 +160,7 @@ class Taxnexcy_FluentForms {
                 continue;
             }
 
-            $value = $this->sanitize_field_value( $value );
+            $value = $this->sanitize_field_value( $value, $labels );
 
             $fields[] = array(
                 'slug'  => $sanitized_key,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
- Stable tag: 1.7.28
+ Stable tag: 1.7.29
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.29 =
+* Use admin labels when formatting repeater field values.
+
 = 1.7.28 =
 * Display values from Fluent Forms repeater fields in WooCommerce emails.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.28
+ * Version:           1.7.29
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.28' );
+define( 'TAXNEXCY_VERSION', '1.7.29' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Label individual repeater values using Fluent Forms admin labels
- Bump plugin version to 1.7.29 and document the change

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_689250b845fc83279b0260bf13c93aea