### PR TITLE
Add labels for repeater values and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.31
+Stable tag: 1.7.32
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.32 =
+* Add fallback labels for repeater field values.
+
 = 1.7.31 =
 * Fix missing labels for Fluent Forms repeater fields in logs and WooCommerce emails.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -80,6 +80,9 @@ class Taxnexcy_FluentForms {
 
                 if ( $label ) {
                     $sanitized[] = sanitize_text_field( $label ) . ': ' . $sub_value;
+                } elseif ( $is_numeric && ! empty( $labels ) ) {
+                    $fallback_label = isset( $label_index[ $key ] ) ? $label_index[ $key ] : $key + 1;
+                    $sanitized[]   = sanitize_text_field( $fallback_label ) . ': ' . $sub_value;
                 } elseif ( is_string( $key ) && $key !== '' && ! is_numeric( $key ) ) {
                     $sanitized[] = sanitize_text_field( $key ) . ': ' . $sub_value;
                 } else {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.31
+Stable tag: 1.7.32
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.32 =
+* Add fallback labels for repeater field values.
+
 = 1.7.31 =
 * Fix missing labels for Fluent Forms repeater fields in logs and WooCommerce emails.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.31
+ * Version:           1.7.32
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.31' );
+define( 'TAXNEXCY_VERSION', '1.7.32' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure repeater field values are labeled when stored
- bump plugin version to 1.7.32

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6893673276988327bb828d407046c415