### PR TITLE
Fix repeater label lookup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.32
+Stable tag: 1.7.33
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,10 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.33 =
+* Preserve labels for Fluent Forms repeater fields.
+* Support the new Repeat Container field.
+
 = 1.7.32 =
 * Add fallback labels for repeater field values.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -203,7 +203,7 @@ class Taxnexcy_FluentForms {
                 $label = $field['settings']['admin_field_label']
                     ?: ( $field['settings']['label'] ?? ( $field['label'] ?? '' ) );
                 if ( $name ) {
-                    if ( 'input_repeat' === ( $field['element'] ?? '' ) && ! empty( $field['fields'] ) ) {
+                    if ( in_array( $field['element'] ?? '', array( 'input_repeat', 'repeat_container' ), true ) && ! empty( $field['fields'] ) ) {
                         $labels[ $name ] = array( '__label' => sanitize_text_field( $label ) );
                         foreach ( $field['fields'] as $child ) {
                             $child_name  = sanitize_key( $child['name'] ?? ( $child['attributes']['name'] ?? '' ) );
@@ -222,7 +222,12 @@ class Taxnexcy_FluentForms {
 
         $fields = array();
         foreach ( $form_data as $key => $value ) {
-            $sanitized_key = sanitize_key( $key );
+            $raw_key       = $key;
+            $sanitized_key = sanitize_key( $raw_key );
+
+            $base_key = strpos( $raw_key, '.' ) !== false
+                ? sanitize_key( strtok( $raw_key, '.' ) )
+                : $sanitized_key;
 
             // Skip internal Fluent Forms fields like nonces or referrers.
             $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id' );
@@ -230,7 +235,7 @@ class Taxnexcy_FluentForms {
                 continue;
             }
 
-            $field_labels  = $labels[ $sanitized_key ] ?? array();
+            $field_labels  = $labels[ $base_key ] ?? array();
             $nested_labels = is_array( $field_labels ) ? $field_labels : array();
             if ( is_array( $nested_labels ) ) {
                 unset( $nested_labels['__label'] );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.32
+Stable tag: 1.7.33
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,10 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.33 =
+* Preserve labels for Fluent Forms repeater fields.
+* Support the new Repeat Container field.
+
 = 1.7.32 =
 * Add fallback labels for repeater field values.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.32
+ * Version:           1.7.33
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.32' );
+define( 'TAXNEXCY_VERSION', '1.7.33' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure repeater field labels are found using raw keys before sanitising
- support Fluent Forms `repeat_container` elements
- bump plugin version to 1.7.33

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_689461a4ea308327bb389986ff24220f