### PR TITLE
Handle repeat container child labels

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.33
+Stable tag: 1.7.34
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.34 =
+* Show labels for fields inside Fluent Forms Repeat Container values.
+
 = 1.7.33 =
 * Preserve labels for Fluent Forms repeater fields.
 * Support the new Repeat Container field.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -203,15 +203,24 @@ class Taxnexcy_FluentForms {
                 $label = $field['settings']['admin_field_label']
                     ?: ( $field['settings']['label'] ?? ( $field['label'] ?? '' ) );
                 if ( $name ) {
-                    if ( in_array( $field['element'] ?? '', array( 'input_repeat', 'repeat_container' ), true ) && ! empty( $field['fields'] ) ) {
+                    if ( in_array( $field['element'] ?? '', array( 'input_repeat', 'repeat_container' ), true ) ) {
                         $labels[ $name ] = array( '__label' => sanitize_text_field( $label ) );
-                        foreach ( $field['fields'] as $child ) {
-                            $child_name  = sanitize_key( $child['name'] ?? ( $child['attributes']['name'] ?? '' ) );
+
+                        $children = array();
+                        if ( ! empty( $field['fields'] ) && is_array( $field['fields'] ) ) {
+                            $children = $field['fields'];
+                        } elseif ( ! empty( $field['columns'] ) && is_array( $field['columns'] ) ) {
+                            foreach ( $field['columns'] as $column ) {
+                                if ( ! empty( $column['fields'] ) && is_array( $column['fields'] ) ) {
+                                    $children = array_merge( $children, $column['fields'] );
+                                }
+                            }
+                        }
+
+                        foreach ( $children as $child ) {
                             $child_label = $child['settings']['admin_field_label']
                                 ?: ( $child['settings']['label'] ?? ( $child['label'] ?? '' ) );
-                            if ( $child_name ) {
-                                $labels[ $name ][ $child_name ] = sanitize_text_field( $child_label );
-                            }
+                            $labels[ $name ][] = sanitize_text_field( $child_label );
                         }
                     } else {
                         $labels[ $name ] = sanitize_text_field( $label );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.33
+Stable tag: 1.7.34
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.34 =
+* Show labels for fields inside Fluent Forms Repeat Container values.
+
 = 1.7.33 =
 * Preserve labels for Fluent Forms repeater fields.
 * Support the new Repeat Container field.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.33
+ * Version:           1.7.34
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.33' );
+define( 'TAXNEXCY_VERSION', '1.7.34' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure labels inside Fluent Forms Repeat Containers are captured by iterating nested columns
- bump plugin version to 1.7.34

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_689464203b388327901123460cc1b1a6