### PR TITLE
Skip internal Fluent Forms fields in order details

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.36
+Stable tag: 1.7.37
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.37 =
+* Exclude additional Fluent Forms internal fields from WooCommerce order details.
+
 = 1.7.36 =
 * Display Fluent Forms repeater tables in WooCommerce emails.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -107,7 +107,7 @@ class Taxnexcy_FluentForms {
         Taxnexcy_Logger::log( 'Processing submission entry ' . $entry_id );
 
         $log_data   = $form_data;
-        $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id' );
+        $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id', 'fluentform_embded_post_id' );
         foreach ( $log_data as $key => $value ) {
             $sanitized_key = sanitize_key( $key );
             if ( in_array( $sanitized_key, $skip_fields, true ) || preg_match( '/^fluentform_\d+_fluentformnonce$/', $sanitized_key ) ) {
@@ -240,7 +240,7 @@ class Taxnexcy_FluentForms {
                 : $sanitized_key;
 
             // Skip internal Fluent Forms fields like nonces or referrers.
-            $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id' );
+            $skip_fields = array( 'fluentform_nonce', 'fluentform_id', 'wp_http_referer', 'fluentform_embed_post_id', 'fluentform_embded_post_id' );
             if ( in_array( $sanitized_key, $skip_fields, true ) || preg_match( '/^fluentform_\d+_fluentformnonce$/', $sanitized_key ) ) {
                 continue;
             }
@@ -385,7 +385,7 @@ class Taxnexcy_FluentForms {
             $label = $order->get_meta( 'taxnexcy_label_' . $slug, true );
 
             // Skip common hidden Fluent Forms fields.
-            if ( in_array( $slug, array( 'wp_http_referer', 'fluentform_nonce', 'fluentform_id', 'fluentform_embed_post_id' ), true ) ||
+            if ( in_array( $slug, array( 'wp_http_referer', 'fluentform_nonce', 'fluentform_id', 'fluentform_embed_post_id', 'fluentform_embded_post_id' ), true ) ||
                 preg_match( '/^fluentform_\d+_fluentformnonce$/', $slug ) ) {
                 continue;
             }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.36
+Stable tag: 1.7.37
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.37 =
+* Exclude additional Fluent Forms internal fields from WooCommerce order details.
+
 = 1.7.36 =
 * Display Fluent Forms repeater tables in WooCommerce emails.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.36
+ * Version:           1.7.37
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.36' );
+define( 'TAXNEXCY_VERSION', '1.7.37' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ignore Fluent Forms internal fields (including the misspelled embed post ID) when saving and displaying order data
- bump plugin version to 1.7.37

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c3eb47ac8327bd636a95ca91b8b5