### PR TITLE
Handle missing Fluent Forms class and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.38
+Stable tag: 1.7.39
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.39 =
+* Prevent fatal errors when Fluent Forms' SubmissionService class is missing.
+
 = 1.7.38 =
 * Display Fluent Forms entries using the plugin's renderer inside WooCommerce orders and emails.
 * Require Fluent Forms 6.0.4+ and cache output under the `_ff_entry_html` order meta key.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -39,12 +39,23 @@ class Taxnexcy_FluentForms {
      * Render a Fluent Forms entry using the plugin's internal renderer.
      *
      * @param int $form_id  Form ID.
-     * @param int $entry_id Entry ID.
-     * @return string HTML for the rendered entry.
+    * @param int $entry_id Entry ID.
+    * @return string HTML for the rendered entry.
      */
     private function render_entry_html( $form_id, $entry_id ) {
+        if ( ! class_exists( '\\FluentForm\\App\\Services\\Submission\\SubmissionService' ) ) {
+            Taxnexcy_Logger::log( 'SubmissionService class not found' );
+            return '';
+        }
+
         $service = new SubmissionService();
-        return $service->renderSubmission( $entry_id, 'table' );
+
+        try {
+            return $service->renderSubmission( $entry_id, 'table' );
+        } catch ( \Throwable $e ) {
+            Taxnexcy_Logger::log( 'Failed to render submission: ' . $e->getMessage() );
+            return '';
+        }
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.37
+Stable tag: 1.7.39
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,9 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.39 =
+* Prevent fatal errors when Fluent Forms' SubmissionService class is missing.
+
 = 1.7.37 =
 * Exclude additional Fluent Forms internal fields from WooCommerce order details.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.38
+ * Version:           1.7.39
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.38' );
+define( 'TAXNEXCY_VERSION', '1.7.39' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- avoid fatal error if Fluent Forms' SubmissionService is missing
- bump plugin version to 1.7.39
- update readme and changelog

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 -P4 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6894d5fea0a88327b70be59937c6e632