### PR TITLE
Handle missing WooCommerce during redirect

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.39
+Stable tag: 1.7.40
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -30,6 +30,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.40 =
+* Avoid fatal errors when WooCommerce is inactive by checking required functions before redirecting to checkout.
 = 1.7.39 =
 * Prevent fatal errors when Fluent Forms' SubmissionService class is missing.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -235,6 +235,10 @@ class Taxnexcy_FluentForms {
      */
     public function maybe_redirect_to_payment( $response, $form_data, $form ) {
         Taxnexcy_Logger::log( 'maybe_redirect_to_payment triggered. Raw data: ' . wp_json_encode( $form_data ) );
+        if ( ! function_exists( 'wc_get_product' ) || ! function_exists( 'wc_get_checkout_url' ) ) {
+            Taxnexcy_Logger::log( 'WooCommerce functions unavailable for redirect' );
+            return $response;
+        }
 
         $product_id = apply_filters( 'taxnexcy_product_id', 0, $form, $form_data );
         $product    = wc_get_product( $product_id );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.39
+Stable tag: 1.7.40
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,8 @@ Define the token in your `wp-config.php` file:
 Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
 
 == Changelog ==
+= 1.7.40 =
+* Avoid fatal errors when WooCommerce is inactive by checking required functions before redirecting to checkout.
 = 1.7.39 =
 * Prevent fatal errors when Fluent Forms' SubmissionService class is missing.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.39
+ * Version:           1.7.40
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.39' );
+define( 'TAXNEXCY_VERSION', '1.7.40' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Prevent fatal errors by verifying WooCommerce functions before redirecting to checkout
- Bump plugin version to 1.7.40 and document the change

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_6894f2d656d48327917fa4f5fd615ab6