### PR TITLE
Remove GitHub token requirement and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.40
+Stable tag: 1.7.41
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -19,17 +19,12 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Automatic Updates ==
-Taxnex Cyprus checks for updates on its GitHub repository. If the repository
-is private you must provide a GitHub token so the updater can access the
-latest release information.
-
-Define the token in your `wp-config.php` file:
-
-`define( 'TAXNEXCY_GITHUB_TOKEN', 'your-personal-access-token' );`
-
-Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
+Taxnex Cyprus checks for updates on its public GitHub repository, so no
+authentication token is required.
 
 == Changelog ==
+= 1.7.41 =
+* Remove GitHub token requirement for updates.
 = 1.7.40 =
 * Avoid fatal errors when WooCommerce is inactive by checking required functions before redirecting to checkout.
 = 1.7.39 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.40
+Stable tag: 1.7.41
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,17 +18,12 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Automatic Updates ==
-Taxnex Cyprus checks for updates on its GitHub repository. If the repository
-is private you must provide a GitHub token so the updater can access the
-latest release information.
-
-Define the token in your `wp-config.php` file:
-
-`define( 'TAXNEXCY_GITHUB_TOKEN', 'your-personal-access-token' );`
-
-Alternatively, set an environment variable named `TAXNEXCY_GITHUB_TOKEN`.
+Taxnex Cyprus checks for updates on its public GitHub repository, so no
+authentication token is required.
 
 == Changelog ==
+= 1.7.41 =
+* Remove GitHub token requirement for updates.
 = 1.7.40 =
 * Avoid fatal errors when WooCommerce is inactive by checking required functions before redirecting to checkout.
 = 1.7.39 =

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.40
+ * Version:           1.7.41
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.40' );
+define( 'TAXNEXCY_VERSION', '1.7.41' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -98,10 +98,6 @@ $taxnexcy_update_checker = PucFactory::buildUpdateChecker(
 );
 $taxnexcy_update_checker->setBranch('main');
 $taxnexcy_update_checker->getVcsApi()->enableReleaseAssets();
-$token = defined('TAXNEXCY_GITHUB_TOKEN') ? TAXNEXCY_GITHUB_TOKEN : getenv('TAXNEXCY_GITHUB_TOKEN');
-if ( ! empty( $token ) ) {
-    $taxnexcy_update_checker->setAuthentication( $token );
-}
 
 /**
  * Resolve product ID for a given Fluent Forms submission.


### PR DESCRIPTION
## Summary
- drop unused GitHub token authentication for update checks
- bump plugin version to 1.7.41 and update documentation

## Testing
- `php -l taxnexcy.php`

------
https://chatgpt.com/codex/tasks/task_e_6894f5ca94f48327bbe145999e054af8