### PR TITLE
Use Fluent Forms renderer for entry output

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.42
+Stable tag: 1.7.43
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.43 =
+* Render Fluent Forms entries using their internal renderer for full entry details.
+
 = 1.7.42 =
 * Render full Fluent Forms single entries in WooCommerce orders and emails.
 * Exclude internal Fluent Forms fields from fallback tables.

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -43,7 +43,7 @@ class Taxnexcy_FluentForms {
     * @return string HTML for the rendered entry.
      */
     private function render_entry_html( $form_id, $entry_id ) {
-        if ( ! class_exists( '\\FluentForm\\App\\Services\\Submission\\SubmissionService' ) ) {
+        if ( ! class_exists( '\FluentForm\App\Services\Submission\SubmissionService' ) ) {
             Taxnexcy_Logger::log( 'SubmissionService class not found' );
             return '';
         }
@@ -51,11 +51,24 @@ class Taxnexcy_FluentForms {
         $service = new SubmissionService();
 
         try {
-            return $service->renderSubmission( $entry_id );
+            if ( method_exists( $service, 'renderSubmission' ) ) {
+                try {
+                    return $service->renderSubmission( $entry_id, $form_id );
+                } catch ( \ArgumentCountError $e ) {
+                    return $service->renderSubmission( $entry_id );
+                }
+            } elseif ( method_exists( $service, 'renderEntry' ) ) {
+                try {
+                    return $service->renderEntry( $entry_id, $form_id );
+                } catch ( \ArgumentCountError $e ) {
+                    return $service->renderEntry( $entry_id );
+                }
+            }
         } catch ( \Throwable $e ) {
             Taxnexcy_Logger::log( 'Failed to render submission: ' . $e->getMessage() );
-            return '';
         }
+
+        return '';
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.42
+Stable tag: 1.7.43
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.43 =
+* Render Fluent Forms entries using their internal renderer for full entry details.
+
 = 1.7.42 =
 * Render full Fluent Forms single entries in WooCommerce orders and emails.
 * Exclude internal Fluent Forms fields from fallback tables.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
  * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
- * Version:           1.7.42
+ * Version:           1.7.43
  * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TAXNEXCY_VERSION', '1.7.42' );
+define( 'TAXNEXCY_VERSION', '1.7.43' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Render Fluent Forms entries with the plugin's internal renderer for full entry details
- Bump plugin version to 1.7.43 and update changelogs

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6894fe7d05c48327810873715c04b83a