### PR TITLE
Log PDF events in main log and bump version to 1.7.47

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.46
+Stable tag: 1.7.47
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.47 =
+* Log PDF generation and email attachments using the main plugin logger.
+
 = 1.7.46 =
 * Switch to session-based Fluent Forms PDF generation, attach to Woo emails and log actions.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.46
+Stable tag: 1.7.47
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.47 =
+* Log PDF generation and email attachments using the main plugin logger.
+
 = 1.7.46 =
 * Switch to session-based Fluent Forms PDF generation, attach to Woo emails and log actions.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.46
+* Version:           1.7.47
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.46' );
+define( 'TAXNEXCY_VERSION', '1.7.47' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Report PDF generation and attachment events through the main Taxnexcy logger.
- Log successful PDF attachments to WooCommerce emails.
- Bump plugin version to 1.7.47 and update changelog.

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6895add8d4dc8327992b13f040bd236d