### PR TITLE
feat: add verbose logging for PDF generation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.50
+Stable tag: 1.7.51
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.51 =
+* Add verbose logging around Fluent Forms PDF generation to help diagnose failures.
+
 = 1.7.50 =
 * Resolve Fluent Forms application container before instantiating the PDF manager to avoid null parameter errors.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.50
+Stable tag: 1.7.51
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.51 =
+* Add verbose logging around Fluent Forms PDF generation to help diagnose failures.
+
 = 1.7.50 =
 * Resolve Fluent Forms application container before instantiating the PDF manager to avoid null parameter errors.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.50
+* Version:           1.7.51
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.50' );
+define( 'TAXNEXCY_VERSION', '1.7.51' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log PDF helper boot sequence and order processing steps using main logger
- add detailed logging around PDF creation fallbacks
- bump plugin version to 1.7.51

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_6895bf1d2d5c8327a7d7e37b9f632909