### PR TITLE
fix: handle PDF generation errors

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.52
+Stable tag: 1.7.53
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,12 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.53 =
+* Prevent checkout failures by catching errors during Fluent Forms PDF generation.
+
+= 1.7.52 =
+* Handle Fluent Forms PDF container initialization more defensively.
+
 = 1.7.51 =
 * Add verbose logging around Fluent Forms PDF generation to help diagnose failures.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.52
+Stable tag: 1.7.53
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,12 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.53 =
+* Prevent checkout failures by catching errors during Fluent Forms PDF generation.
+
+= 1.7.52 =
+* Handle Fluent Forms PDF container initialization more defensively.
+
 = 1.7.51 =
 * Add verbose logging around Fluent Forms PDF generation to help diagnose failures.
 

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.0.6';
+    const VER                 = '1.0.7';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -101,7 +101,18 @@ final class Taxnexcy_FF_PDF_Attach {
         $form_id  = (int) $map['form_id'];
         $entry_id = (int) $map['entry_id'];
 
-        $pdf_path = $this->create_pdf_for_entry( $form_id, $entry_id, $order_id );
+        try {
+            $pdf_path = $this->create_pdf_for_entry( $form_id, $entry_id, $order_id );
+        } catch ( \Throwable $e ) {
+            $this->log( 'PDF generation exception', [
+                'order_id' => $order_id,
+                'form_id'  => $form_id,
+                'entry_id' => $entry_id,
+                'message'  => $e->getMessage(),
+            ] );
+            return;
+        }
+
         if ( $pdf_path ) {
             $order->update_meta_data( self::ORDER_META_PDF_PATH, $pdf_path );
             $order->save();

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.52
+* Version:           1.7.53
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.52' );
+define( 'TAXNEXCY_VERSION', '1.7.53' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- handle Fluent Forms PDF generation errors so checkout isn't blocked
- bump plugin version to 1.7.53

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_6895c5a7bee08327900533e545c9cf7d