### PR TITLE
Log WooCommerce checkout errors

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.53
+Stable tag: 1.7.54
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.54 =
+* Log WooCommerce checkout data and errors to help debug order processing failures.
 = 1.7.53 =
 * Prevent checkout failures by catching errors during Fluent Forms PDF generation.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -33,6 +33,9 @@ class Taxnexcy_FluentForms {
         add_action( 'woocommerce_email_order_meta', array( $this, 'display_email_entry' ), 10, 4 );
         add_action( 'woocommerce_admin_order_data_after_order_details', array( $this, 'display_admin_meta_fields' ), 15 );
         add_action( 'woocommerce_checkout_create_order', array( $this, 'add_session_fields_to_order' ), 10, 2 );
+        add_action( 'woocommerce_checkout_process', array( $this, 'log_checkout_request' ) );
+        add_action( 'woocommerce_checkout_order_processed', array( $this, 'log_checkout_processed' ), 10, 3 );
+        add_filter( 'woocommerce_add_error', array( $this, 'log_woocommerce_error' ) );
     }
 
     /**
@@ -323,6 +326,36 @@ class Taxnexcy_FluentForms {
         WC()->session->set( '_ff_entry_id', null );
         WC()->session->set( '_ff_entry_html', null );
         Taxnexcy_Logger::log( 'Added session fields to order ' . $order->get_id() );
+    }
+
+    /**
+     * Log checkout request data before WooCommerce processes it.
+     */
+    public function log_checkout_request() {
+        $posted = wc_clean( wp_unslash( $_POST ) );
+        Taxnexcy_Logger::log( 'Checkout process data: ' . wp_json_encode( $posted ) );
+    }
+
+    /**
+     * Log when an order is successfully processed at checkout.
+     *
+     * @param int      $order_id     The order ID.
+     * @param array    $posted_data  Sanitized checkout data.
+     * @param WC_Order $order        The order object.
+     */
+    public function log_checkout_processed( $order_id, $posted_data, $order ) {
+        Taxnexcy_Logger::log( 'Checkout order processed. ID: ' . $order_id . ' Data: ' . wp_json_encode( $posted_data ) );
+    }
+
+    /**
+     * Log any WooCommerce checkout errors.
+     *
+     * @param string $error Error message.
+     * @return string Unmodified error message.
+     */
+    public function log_woocommerce_error( $error ) {
+        Taxnexcy_Logger::log( 'WooCommerce error notice: ' . $error );
+        return $error;
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.53
+Stable tag: 1.7.54
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.54 =
+* Log WooCommerce checkout data and errors to help debug order processing failures.
 = 1.7.53 =
 * Prevent checkout failures by catching errors during Fluent Forms PDF generation.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.53
+* Version:           1.7.54
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.53' );
+define( 'TAXNEXCY_VERSION', '1.7.54' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log WooCommerce checkout request data, successful order creation, and error notices
- bump plugin version to 1.7.54 with updated readmes

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6895c8e4f3a8832783a489a8f0635a4c