### PR TITLE
Check cart before adding product

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.55
+Stable tag: 1.7.56
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.56 =
+* Skip adding product to cart if it is already present and log the cart state.
+
 = 1.7.55 =
 * Avoid duplicate add-to-cart errors for individually sold products.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -262,11 +262,15 @@ class Taxnexcy_FluentForms {
         $url     = wc_get_checkout_url();
         $add_cart = true;
 
-        if ( function_exists( 'WC' ) && WC()->cart && $product->is_sold_individually() ) {
-            $cart_id = WC()->cart->generate_cart_id( $product_id );
-            if ( WC()->cart->find_product_in_cart( $cart_id ) ) {
+        if ( function_exists( 'WC' ) && WC()->cart ) {
+            $cart      = WC()->cart;
+            $cart_stat = $cart->is_empty() ? 'empty' : 'not empty';
+            Taxnexcy_Logger::log( 'Cart is ' . $cart_stat . ' before attempting add-to-cart for product ' . $product_id );
+
+            $cart_id = $cart->generate_cart_id( $product_id );
+            if ( $cart->find_product_in_cart( $cart_id ) ) {
                 $add_cart = false;
-                Taxnexcy_Logger::log( 'Product already in cart and sold individually. Skipping add-to-cart for product ' . $product_id );
+                Taxnexcy_Logger::log( 'Product already in cart. Skipping add-to-cart for product ' . $product_id );
             }
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.55
+Stable tag: 1.7.56
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.56 =
+* Skip adding product to cart if it is already present and log the cart state.
+
 = 1.7.55 =
 * Avoid duplicate add-to-cart errors for individually sold products.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.55
+* Version:           1.7.56
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.55' );
+define( 'TAXNEXCY_VERSION', '1.7.56' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure product is not added to cart if already present
- log cart state before redirecting to checkout
- bump plugin version to 1.7.56 and update changelog

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_6895cf5d5a1883278b6b08de51dfa6c0