### PR TITLE
Empty cart on page 100507 and bump version to 1.7.57

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.56
+Stable tag: 1.7.57
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.57 =
+* Empty WooCommerce cart when accessing page ID 100507.
+
 = 1.7.56 =
 * Skip adding product to cart if it is already present and log the cart state.
 

--- a/includes/class-taxnexcy.php
+++ b/includes/class-taxnexcy.php
@@ -185,6 +185,7 @@ require_once plugin_dir_path( dirname( __FILE__ ) ) . 'taxnexcy-ff-pdf-attachmen
                 $this->loader->add_filter( 'woocommerce_my_account_my_orders_actions', $plugin_public, 'remove_my_account_order_actions', 10, 2 );
                 $this->loader->add_filter( 'woocommerce_valid_order_statuses_for_payment', $plugin_public, 'disable_order_pay_button', 10, 2 );
                 $this->loader->add_filter( 'woocommerce_valid_order_statuses_for_cancel', $plugin_public, 'disable_order_cancel_button', 10, 2 );
+               $this->loader->add_action( 'template_redirect', $plugin_public, 'empty_cart_on_page' );
 
                 $fluentforms = new Taxnexcy_FluentForms( $this->get_version() );
 

--- a/public/class-taxnexcy-public.php
+++ b/public/class-taxnexcy-public.php
@@ -135,4 +135,16 @@ wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy
                return array();
        }
 
+       /**
+        * Empty the WooCommerce cart when visiting page ID 100507.
+        *
+        * @since    1.7.57
+        * @return void
+        */
+       public function empty_cart_on_page() {
+               if ( function_exists( 'is_page' ) && is_page( 100507 ) && function_exists( 'WC' ) && WC()->cart ) {
+                       WC()->cart->empty_cart();
+               }
+       }
+
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.56
+Stable tag: 1.7.57
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.57 =
+* Empty WooCommerce cart when accessing page ID 100507.
+
 = 1.7.56 =
 * Skip adding product to cart if it is already present and log the cart state.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.56
+* Version:           1.7.57
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.56' );
+define( 'TAXNEXCY_VERSION', '1.7.57' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Clear WooCommerce cart automatically when page ID 100507 is visited.
- Register the cart clearing hook and increment plugin to version 1.7.57.

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy.php`
- `php -l public/class-taxnexcy-public.php`


------
https://chatgpt.com/codex/tasks/task_e_6895d51340b08327a2b853b9eae80b11