### PR TITLE
Handle PDF method variations

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.57
+Stable tag: 1.7.58
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.58 =
+* Try multiple Fluent Forms PDF generator signatures to prevent fatal errors during checkout.
+
 = 1.7.57 =
 * Empty WooCommerce cart when accessing page ID 100507.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.57
+Stable tag: 1.7.58
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.58 =
+* Try multiple Fluent Forms PDF generator signatures to prevent fatal errors during checkout.
+
 = 1.7.57 =
 * Empty WooCommerce cart when accessing page ID 100507.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.57
+ * Version:           1.7.58
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.57' );
+define( 'TAXNEXCY_VERSION', '1.7.58' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- guard PDF generation against GlobalPdfManager parameter changes by trying multiple signatures
- bump plugin version to 1.7.58 with updated documentation

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6895d771650483278774a3af377d9fa8