### PR TITLE
Default to fallback product when mapping is missing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.59
+Stable tag: 1.7.60
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.60 =
+* Default to fallback product ID 100506 when mapping is missing and log the decision.
+
 = 1.7.59 =
 * Log cart contents and session data to debug checkout issues.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -252,7 +252,14 @@ class Taxnexcy_FluentForms {
         }
 
         $product_id = apply_filters( 'taxnexcy_product_id', 0, $form, $form_data );
-        $product    = wc_get_product( $product_id );
+        Taxnexcy_Logger::log( 'Product ID resolved from mapping: ' . $product_id );
+
+        if ( ! $product_id ) {
+            $product_id = 100506;
+            Taxnexcy_Logger::log( 'No mapped product ID; using fallback product ID ' . $product_id );
+        }
+
+        $product = wc_get_product( $product_id );
 
         if ( ! $product ) {
             Taxnexcy_Logger::log( 'Product not found for redirect. ID: ' . $product_id );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.59
+Stable tag: 1.7.60
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.60 =
+* Default to fallback product ID 100506 when mapping is missing and log the decision.
+
 = 1.7.59 =
 * Log cart contents and session data to debug checkout issues.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.59
+* Version:           1.7.60
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.59' );
+define( 'TAXNEXCY_VERSION', '1.7.60' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- default to WooCommerce product ID 100506 when form-to-product mapping returns 0
- bump plugin version to 1.7.60 and document the change

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6895dd95f988832796723f781b43872c