### PR TITLE
Add form mapping fallback and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.61
+Stable tag: 1.7.62
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.62 =
+* Provide fallback mapping for Form 4 to product 100506.
+
 = 1.7.61 =
 * Improve checkout redirect logic and verify product is purchasable.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.61
+Stable tag: 1.7.62
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.62 =
+* Provide fallback mapping for Form 4 to product 100506.
+
 = 1.7.61 =
 * Improve checkout redirect logic and verify product is purchasable.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.61
+* Version:           1.7.62
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.61' );
+define( 'TAXNEXCY_VERSION', '1.7.62' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -43,7 +43,9 @@ define( 'TAXNEXCY_VERSION', '1.7.61' );
  * define( 'TAXNEXCY_FORM_PRODUCTS', array( 10 => 123, 20 => 456 ) );
  */
 if ( ! defined( 'TAXNEXCY_FORM_PRODUCTS' ) ) {
-    define( 'TAXNEXCY_FORM_PRODUCTS', array() );
+    define( 'TAXNEXCY_FORM_PRODUCTS', array(
+        4 => 100506, // Form ID => Product ID
+    ) );
 }
 
 /**


### PR DESCRIPTION
## Summary
- add hardcoded mapping constant for Fluent Form 4 to product 100506
- bump plugin version to 1.7.62 and update documentation

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_6895e56aeecc832780686543194b7c93