### PR TITLE
feat: expand WooCommerce logging

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.62
+Stable tag: 1.7.64
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,13 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.64 =
+* Add logging for WooCommerce order status changes, cart loads, and cart clearing.
+* Record order action restrictions and cart resets for easier debugging.
+
+= 1.7.63 =
+* Replace Fluent Forms PDF attachment helper with enhanced version 1.1.0.
+
 = 1.7.62 =
 * Provide fallback mapping for Form 4 to product 100506.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -36,6 +36,8 @@ class Taxnexcy_FluentForms {
         add_action( 'woocommerce_checkout_process', array( $this, 'log_checkout_request' ) );
         add_action( 'woocommerce_checkout_order_processed', array( $this, 'log_checkout_processed' ), 10, 3 );
         add_filter( 'woocommerce_add_error', array( $this, 'log_woocommerce_error' ) );
+        add_action( 'woocommerce_order_status_changed', array( $this, 'log_order_status_change' ), 10, 4 );
+        add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'log_cart_loaded_from_session' ) );
     }
 
     /**
@@ -428,6 +430,29 @@ class Taxnexcy_FluentForms {
     public function log_woocommerce_error( $error ) {
         Taxnexcy_Logger::log( 'WooCommerce error notice: ' . $error );
         return $error;
+    }
+
+    /**
+     * Log order status transitions for debugging.
+     *
+     * @param int      $order_id   Order ID.
+     * @param string   $old_status Previous status slug.
+     * @param string   $new_status New status slug.
+     * @param WC_Order $order      Order object.
+     */
+    public function log_order_status_change( $order_id, $old_status, $new_status, $order ) {
+        Taxnexcy_Logger::log( 'Order ' . $order_id . ' status changed from ' . $old_status . ' to ' . $new_status );
+    }
+
+    /**
+     * Log cart contents when loaded from the session.
+     *
+     * @param WC_Cart $cart Cart object.
+     */
+    public function log_cart_loaded_from_session( $cart ) {
+        if ( is_object( $cart ) && method_exists( $cart, 'get_cart' ) ) {
+            Taxnexcy_Logger::log( 'Cart loaded from session: ' . wp_json_encode( $cart->get_cart() ) );
+        }
     }
 
     /**

--- a/public/class-taxnexcy-public.php
+++ b/public/class-taxnexcy-public.php
@@ -108,6 +108,8 @@ wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy
         * @return array Modified order actions.
         */
        public function remove_my_account_order_actions( $actions, $order ) {
+               $order_id = is_object( $order ) && method_exists( $order, 'get_id' ) ? $order->get_id() : 'unknown';
+               Taxnexcy_Logger::log( 'Removing pay and cancel actions for order ' . $order_id );
                unset( $actions['pay'] );
                unset( $actions['cancel'] );
                return $actions;
@@ -121,6 +123,9 @@ wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy
         * @return array
         */
        public function disable_order_pay_button( $statuses, $order ) {
+               $order_id = is_object( $order ) && method_exists( $order, 'get_id' ) ? $order->get_id() : 'unknown';
+               $status   = is_object( $order ) && method_exists( $order, 'get_status' ) ? $order->get_status() : 'unknown';
+               Taxnexcy_Logger::log( 'Disabling pay button for order ' . $order_id . ' with status ' . $status );
                return array();
        }
 
@@ -132,6 +137,9 @@ wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy
         * @return array
         */
        public function disable_order_cancel_button( $statuses, $order ) {
+               $order_id = is_object( $order ) && method_exists( $order, 'get_id' ) ? $order->get_id() : 'unknown';
+               $status   = is_object( $order ) && method_exists( $order, 'get_status' ) ? $order->get_status() : 'unknown';
+               Taxnexcy_Logger::log( 'Disabling cancel button for order ' . $order_id . ' with status ' . $status );
                return array();
        }
 
@@ -143,7 +151,9 @@ wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy
         */
        public function empty_cart_on_page() {
                if ( function_exists( 'is_page' ) && is_page( 100507 ) && function_exists( 'WC' ) && WC()->cart ) {
+                       Taxnexcy_Logger::log( 'Emptying cart on page 100507. Contents before: ' . wp_json_encode( WC()->cart->get_cart() ) );
                        WC()->cart->empty_cart();
+                       Taxnexcy_Logger::log( 'Cart emptied on page 100507' );
                }
        }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.63
+Stable tag: 1.7.64
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.64 =
+* Add logging for WooCommerce order status changes, cart loads, and cart clearing.
+* Record order action restrictions and cart resets for easier debugging.
+
 = 1.7.63 =
 * Replace Fluent Forms PDF attachment helper with enhanced version 1.1.0.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.63
+* Version:           1.7.64
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.63' );
+define( 'TAXNEXCY_VERSION', '1.7.64' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log WooCommerce order status changes and cart data for deeper diagnostics
- trace front-end order actions and cart resets
- bump plugin version to 1.7.64

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l public/class-taxnexcy-public.php`

------
https://chatgpt.com/codex/tasks/task_e_6895f34ff7b48327b20d3e4d4320898c