### PR TITLE
Handle new Fluent Forms PDF API

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.65
+Stable tag: 1.7.66
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.66 =
+* Generate PDFs with Fluent Forms' default template when GlobalPdfManager lacks generation methods.
 = 1.7.64 =
 * Add logging for WooCommerce order status changes, cart loads, and cart clearing.
 * Record order action restrictions and cart resets for easier debugging.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.65
+Stable tag: 1.7.66
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.66 =
+* Generate PDFs with Fluent Forms' default template when GlobalPdfManager lacks generation methods.
 = 1.7.64 =
 * Add logging for WooCommerce order status changes, cart loads, and cart clearing.
 * Record order action restrictions and cart resets for easier debugging.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.65
+* Version:           1.7.66
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.65' );
+define( 'TAXNEXCY_VERSION', '1.7.66' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Generate PDFs with default template when GlobalPdfManager lacks generation methods
- Bump plugin version to 1.7.66

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/taxnexcy/package.json')*
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_6895fa05fb848327a8bdc6813db9ae32