### PR TITLE
Restrict PDF generation to target form

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.66
+Stable tag: 1.7.67
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.67 =
+* Restrict PDF generation to Form ID 4 to prevent missing form errors.
+
 = 1.7.66 =
 * Generate PDFs with Fluent Forms' default template when GlobalPdfManager lacks generation methods.
 = 1.7.64 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.66
+Stable tag: 1.7.67
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.67 =
+* Restrict PDF generation to Form ID 4 to prevent missing form errors.
+
 = 1.7.66 =
 * Generate PDFs with Fluent Forms' default template when GlobalPdfManager lacks generation methods.
 = 1.7.64 =

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,10 +17,11 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.2';
+    const VER                 = '1.1.3';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
+    const TARGET_FORM_ID      = 4;
 
     public function __construct() {
         add_action( 'plugins_loaded', [ $this, 'maybe_boot' ], 20 );
@@ -64,6 +65,11 @@ final class Taxnexcy_FF_PDF_Attach {
      * find it during checkout → order creation.
      */
     public function capture_ff_entry_in_session( $entry_id, $form_id, $form_data ) {
+        if ( (int) $form_id !== self::TARGET_FORM_ID ) {
+            $this->log( 'Ignoring FF submission for non-target form', [ 'form_id' => (int) $form_id ] );
+            return;
+        }
+
         if ( function_exists( 'WC' ) && WC()->session ) {
             $map = [
                 'form_id'  => (int) $form_id,
@@ -95,6 +101,11 @@ final class Taxnexcy_FF_PDF_Attach {
         }
 
         $form_id  = (int) $map['form_id'];
+        if ( $form_id !== self::TARGET_FORM_ID ) {
+            $this->log( 'Form ID mismatch; skipping PDF generation', [ 'form_id' => $form_id ] );
+            return;
+        }
+
         $entry_id = (int) $map['entry_id'];
 
         try {

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.66
+* Version:           1.7.67
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.66' );
+define( 'TAXNEXCY_VERSION', '1.7.67' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure Fluent Forms PDF helper only captures and processes form ID 4
- bump plugin version and changelog to 1.7.67

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6895fef04ca88327a4d89c379e6d5483