### PR TITLE
Remove checkout redirect logic

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,11 +4,11 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.67
+Stable tag: 1.7.68
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and redirects users to checkout for payment.
+Taxnex Cyprus converts FluentForms submissions into WooCommerce customers.
 Requires Fluent Forms 6.0.4 or higher and stores the rendered entry under the `_ff_entry_html` order meta key.
 
 == Description ==
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.68 =
+* Remove redundant checkout redirect handling now managed by Fluent Forms.
+
 = 1.7.67 =
 * Restrict PDF generation to Form ID 4 to prevent missing form errors.
 

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -26,10 +26,6 @@ class Taxnexcy_FluentForms {
         Taxnexcy_Logger::log( 'Initialising FluentForms integration' );
 
         add_action( 'fluentform_submission_inserted', array( $this, 'create_customer' ), 10, 3 );
-        add_filter( 'fluentform_submission_response', array( $this, 'maybe_redirect_to_payment' ), 10, 3 );
-        // Fallback filter name used by some Fluent Forms versions.
-        add_filter( 'fluentform_submit_response', array( $this, 'maybe_redirect_to_payment' ), 10, 3 );
-        Taxnexcy_Logger::log( 'Redirect filters registered' );
         add_action( 'woocommerce_email_order_meta', array( $this, 'display_email_entry' ), 10, 4 );
         add_action( 'woocommerce_admin_order_data_after_order_details', array( $this, 'display_admin_meta_fields' ), 15 );
         add_action( 'woocommerce_checkout_create_order', array( $this, 'add_session_fields_to_order' ), 10, 2 );
@@ -237,109 +233,6 @@ class Taxnexcy_FluentForms {
             Taxnexcy_Logger::log( 'Stored fields in session: ' . wp_json_encode( $legacy_fields ) );
         }
     }
-
-    /**
-     * Redirect users to the WooCommerce checkout after submission.
-     *
-     * @param array $response Original response.
-     * @param array $form_data Form data.
-     * @param array $form Form settings.
-     * @return array
-     */
-    public function maybe_redirect_to_payment( $response, $form_data, $form ) {
-        Taxnexcy_Logger::log( 'maybe_redirect_to_payment triggered. Raw data: ' . wp_json_encode( $form_data ) );
-
-        // Sanity check: WooCommerce functions must exist.
-        if ( ! function_exists( 'wc_get_product' ) || ! function_exists( 'wc_get_checkout_url' ) ) {
-            Taxnexcy_Logger::log( 'WooCommerce functions unavailable for redirect' );
-            return $response;
-        }
-
-        // Resolve product via mapping filter (admin option or constant).
-        $product_id = apply_filters( 'taxnexcy_product_id', 0, $form, $form_data );
-
-        // Hard fallback so checkout still works even if mapping is empty/misconfigured.
-        if ( ! $product_id ) {
-            $product_id = 100506; // 👈 YOUR DEFAULT PRODUCT ID
-            Taxnexcy_Logger::log( 'Mapping returned empty product. Using fallback product ID: ' . $product_id );
-        }
-
-        $product = wc_get_product( $product_id );
-        if ( ! $product ) {
-            Taxnexcy_Logger::log( 'Product not found for redirect. ID: ' . $product_id );
-            return $response;
-        }
-
-        // Extra guard: product must be purchasable.
-        if ( method_exists( $product, 'is_purchasable' ) && ! $product->is_purchasable() ) {
-            Taxnexcy_Logger::log( 'Product not purchasable: ' . $product_id );
-            return $response;
-        }
-
-        Taxnexcy_Logger::log( 'Product for redirect: ' . $product_id . ' - ' . $product->get_name() );
-
-        $url      = wc_get_checkout_url();
-        $add_cart = true;
-
-        // If cart is available, avoid duplicating the same product.
-        if ( function_exists( 'WC' ) && WC()->cart ) {
-            $cart = WC()->cart;
-            $cart_stat = $cart->is_empty() ? 'empty' : 'not empty';
-            Taxnexcy_Logger::log( 'Cart is ' . $cart_stat . ' before attempting add-to-cart for product ' . $product_id );
-            Taxnexcy_Logger::log( 'Current cart contents: ' . wp_json_encode( $cart->get_cart() ) );
-
-            $cart_id = $cart->generate_cart_id( $product_id );
-            if ( $cart->find_product_in_cart( $cart_id ) ) {
-                $add_cart = false;
-                Taxnexcy_Logger::log( 'Product already in cart. Skipping add-to-cart for product ' . $product_id );
-            }
-        } else {
-            Taxnexcy_Logger::log( 'Cart not available before redirect.' );
-        }
-
-        // Build checkout URL. If adding item, pass add-to-cart param.
-        if ( $add_cart ) {
-            $url = add_query_arg(
-                array(
-                    'add-to-cart' => $product_id,
-                    'quantity'    => 1,
-                ),
-                $url
-            );
-            Taxnexcy_Logger::log( 'Redirecting to checkout with add-to-cart for product ' . $product_id );
-        } else {
-            Taxnexcy_Logger::log( 'Redirecting to checkout without adding product ' . $product_id );
-        }
-
-        Taxnexcy_Logger::log( 'Checkout URL with cart params: ' . $url );
-
-        // Allow disabling redirect via constant/filter.
-        $should_redirect = ! ( defined( 'TAXNEXCY_DISABLE_REDIRECT' ) && TAXNEXCY_DISABLE_REDIRECT );
-        $should_redirect = apply_filters( 'taxnexcy_redirect_to_payment', $should_redirect, $product_id );
-
-        if ( $url && $should_redirect ) {
-            // Provide multiple keys for compatibility across Fluent Forms versions.
-            $response['redirect_to']  = $url;
-            $response['redirect_url'] = $url;
-            $response['redirectTo']   = $url;
-
-            // If this was a non-AJAX submission, do a server-side redirect too.
-            if ( ! wp_doing_ajax() ) {
-                wp_safe_redirect( $url );
-                exit;
-            }
-
-            Taxnexcy_Logger::log( 'Redirecting to checkout for product ' . $product_id );
-        } elseif ( ! $should_redirect ) {
-            Taxnexcy_Logger::log( 'Redirect disabled for product ' . $product_id );
-        } else {
-            Taxnexcy_Logger::log( 'Checkout URL empty for product ' . $product_id );
-        }
-
-        Taxnexcy_Logger::log( 'Response after redirect check: ' . wp_json_encode( $response ) );
-        return $response;
-    }
-
     /**
      * Add saved Fluent Forms fields from the session to WooCommerce order meta.
      *

--- a/readme.txt
+++ b/readme.txt
@@ -4,11 +4,11 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.67
+Stable tag: 1.7.68
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Taxnex Cyprus converts FluentForms submissions into WooCommerce customers and redirects users to checkout for payment.
+Taxnex Cyprus converts FluentForms submissions into WooCommerce customers.
 
 == Description ==
 This plugin integrates FluentForms with WooCommerce to create customers and process payments automatically.
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.68 =
+* Remove redundant checkout redirect handling now managed by Fluent Forms.
+
 = 1.7.67 =
 * Restrict PDF generation to Form ID 4 to prevent missing form errors.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -15,8 +15,8 @@
  * @wordpress-plugin
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
-* Description:       Creates WooCommerce user from FluentForms submission and redirects to checkout
-* Version:           1.7.67
+* Description:       Creates WooCommerce user from FluentForms submission
+* Version:           1.7.68
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.67' );
+define( 'TAXNEXCY_VERSION', '1.7.68' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -52,14 +52,6 @@ if ( ! defined( 'TAXNEXCY_FORM_PRODUCTS' ) ) {
  * Option key used to store form to product mappings.
  */
 define( 'TAXNEXCY_FORM_PRODUCTS_OPTION', 'taxnexcy_form_products' );
-
-/**
- * Disable automatic redirect to the payment page after form submission.
- * Define TAXNEXCY_DISABLE_REDIRECT as true in wp-config.php to keep users on the form page.
- */
-if ( ! defined( 'TAXNEXCY_DISABLE_REDIRECT' ) ) {
-    define( 'TAXNEXCY_DISABLE_REDIRECT', false );
-}
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
## Summary
- drop custom redirect hooks so Fluent Forms handles checkout navigation
- bump plugin version to 1.7.68 and update readmes

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-taxnexcy-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_689604b164fc83279761624e4d30ff87