### PR TITLE
Fix duplicate plugin boot and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.68
+Stable tag: 1.7.69
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.69 =
+* Prevent duplicate plugin initialisation when the file is loaded more than once.
+
 = 1.7.68 =
 * Remove redundant checkout redirect handling now managed by Fluent Forms.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.68
+Stable tag: 1.7.69
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.69 =
+* Prevent duplicate plugin initialisation when the file is loaded more than once.
+
 = 1.7.68 =
 * Remove redundant checkout redirect handling now managed by Fluent Forms.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.68
+* Version:           1.7.69
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.68' );
+define( 'TAXNEXCY_VERSION', '1.7.69' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.
@@ -190,4 +190,8 @@ function run_taxnexcy() {
         $plugin->run();
 
 }
-  run_taxnexcy();
+
+if ( ! defined( 'TAXNEXCY_LOADED' ) ) {
+        define( 'TAXNEXCY_LOADED', true );
+        run_taxnexcy();
+}


### PR DESCRIPTION
## Summary
- ensure Taxnexcy only boots once per request to avoid repeated logs
- bump plugin version to 1.7.69 and document change

## Testing
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_689606d05fc88327b5037639e398b342