### PR TITLE
Fix form ID mapping and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.69
+Stable tag: 1.7.70
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.70 =
+* Store the correct Fluent Forms ID in the WooCommerce session map.
+
 = 1.7.69 =
 * Prevent duplicate plugin initialisation when the file is loaded more than once.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.69
+Stable tag: 1.7.70
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.70 =
+* Store the correct Fluent Forms ID in the WooCommerce session map.
+
 = 1.7.69 =
 * Prevent duplicate plugin initialisation when the file is loaded more than once.
 

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -64,15 +64,25 @@ final class Taxnexcy_FF_PDF_Attach {
      * Save the last FF submission (form + entry) into WC session so we can
      * find it during checkout → order creation.
      */
-    public function capture_ff_entry_in_session( $entry_id, $form_id, $form_data ) {
-        if ( (int) $form_id !== self::TARGET_FORM_ID ) {
-            $this->log( 'Ignoring FF submission for non-target form', [ 'form_id' => (int) $form_id ] );
+    public function capture_ff_entry_in_session( $entry_id, $form_data, $form ) {
+        $form_id = 0;
+
+        if ( is_array( $form ) && ! empty( $form['id'] ) ) {
+            $form_id = (int) $form['id'];
+        } elseif ( is_object( $form ) && ! empty( $form->id ) ) {
+            $form_id = (int) $form->id;
+        } elseif ( is_array( $form_data ) && ! empty( $form_data['form_id'] ) ) {
+            $form_id = (int) $form_data['form_id'];
+        }
+
+        if ( $form_id !== self::TARGET_FORM_ID ) {
+            $this->log( 'Ignoring FF submission for non-target form', [ 'form_id' => $form_id ] );
             return;
         }
 
         if ( function_exists( 'WC' ) && WC()->session ) {
             $map = [
-                'form_id'  => (int) $form_id,
+                'form_id'  => $form_id,
                 'entry_id' => (int) $entry_id,
             ];
             WC()->session->set( self::SESSION_KEY, $map );

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.69
+* Version:           1.7.70
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.69' );
+define( 'TAXNEXCY_VERSION', '1.7.70' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- fix session map capturing by resolving real form ID from Fluent Forms hook
- bump plugin version to 1.7.70 and update changelog

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_68960c320ed08327a9e58c68ee8e1f4c