### PR TITLE
Use Fluent Forms smartcodes in PDF attachments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.72
+Stable tag: 1.7.73
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.73 =
+* Use Fluent Forms smartcodes for PDF metadata and file names.
+
 = 1.7.72 =
 * Set PDF title to "Taxnex TaxisNet Submission for {user.name}" and include Divi logo.
 * Apply site colours to generated PDFs.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.72
+Stable tag: 1.7.73
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.73 =
+* Use Fluent Forms smartcodes for PDF file names and headings.
+* Bump PDF helper to version 1.1.6.
+
 = 1.7.72 =
 * Set PDF title to "Taxnex TaxisNet Submission for {user.name}".
 * Use Divi theme logo and site colours in generated PDFs.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.72
+* Version:           1.7.73
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.72' );
+define( 'TAXNEXCY_VERSION', '1.7.73' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- switch PDF metadata to Fluent Forms `{inputs.*}` smartcodes and support them in replacement logic
- bump helper and plugin versions

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6896e4409d448327a64cbc738f925b4b