### PR TITLE
Handle dynamic smartcodes in PDFs and bump version to 1.7.74

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.73
+Stable tag: 1.7.74
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.74 =
+* Replace user and dynamic smartcodes inside generated PDFs.
+* Apply form colours and titles to PDF output.
+
 = 1.7.73 =
 * Use Fluent Forms smartcodes for PDF metadata and file names.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.73
+Stable tag: 1.7.74
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.74 =
+* Replace user and dynamic smartcodes inside generated PDFs.
+* Apply form colours and titles to PDF output.
+
 = 1.7.73 =
 * Use Fluent Forms smartcodes for PDF file names and headings.
 * Bump PDF helper to version 1.1.6.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.73
+* Version:           1.7.74
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.73' );
+define( 'TAXNEXCY_VERSION', '1.7.74' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- expand PDF smartcode replacement to include user and dynamic fields
- supply explicit title and CSS settings so PDF headers and colours are applied
- bump plugin version to 1.7.74

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6896ea38c1b883279ddd17f2bb81d1f0