### PR TITLE
feat: add custom PDF template for styled PDFs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.74
+Stable tag: 1.7.76
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,14 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.76 =
+* Ensure custom PDF template is used via TemplateManager settings.
+* Bump PDF helper to version 1.1.8.
+
+= 1.7.75 =
+* Load a custom template for generated PDFs so style changes are reflected.
+* Bump PDF helper to version 1.1.7.
+
 = 1.7.74 =
 * Replace user and dynamic smartcodes inside generated PDFs.
 * Apply form colours and titles to PDF output.

--- a/public/pdf-template.html
+++ b/public/pdf-template.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body{font-family:Arial,sans-serif;color:#000;}
+        h1{color:#078586;}
+        table{width:100%;border-collapse:collapse;}
+        th,td{padding:5px;border:1px solid #ccc;text-align:left;}
+    </style>
+</head>
+<body>
+<h1>Taxnex TaxisNet Submission</h1>
+<p>Name: {inputs.names.first_name} {inputs.names.last_name}</p>
+<p>Email: {user.user_email}</p>
+</body>
+</html>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.74
+Stable tag: 1.7.76
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,14 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.76 =
+* Ensure custom PDF template is used via TemplateManager settings.
+* Bump PDF helper to version 1.1.8.
+
+= 1.7.75 =
+* Load a custom template for generated PDFs so style changes are reflected.
+* Bump PDF helper to version 1.1.7.
+
 = 1.7.74 =
 * Replace user and dynamic smartcodes inside generated PDFs.
 * Apply form colours and titles to PDF output.

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.6';
+    const VER                 = '1.1.8';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -484,6 +484,14 @@ final class Taxnexcy_FF_PDF_Attach {
         $logo = $this->get_divi_logo_url();
         if ( $logo ) {
             $settings['logo'] = $logo;
+        }
+        // Load a custom template if available so styling changes take effect.
+        $template_path = plugin_dir_path( __FILE__ ) . 'public/pdf-template.html';
+        if ( file_exists( $template_path ) ) {
+            $settings['template_key']   = 'custom';
+            $settings['template']       = 'custom';
+            $settings['use_custom_html'] = true;
+            $settings['custom_html']    = file_get_contents( $template_path );
         }
 
         return $this->replace_dynamic_tags( $settings, $form_id, $entry_id );

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.74
+* Version:           1.7.76
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.74' );
+define( 'TAXNEXCY_VERSION', '1.7.76' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- ensure Fluent Forms PDF generation uses custom HTML template via TemplateManager
- bump plugin to version 1.7.76 and PDF helper to 1.1.8
- document new version and template behavior in readme files

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_6896ec9a76bc8327891d286fa356a6c9