### PR TITLE
Revert PDF settings merge and bump version to 1.7.78

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.77
+Stable tag: 1.7.78
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.77
+Stable tag: 1.7.78
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.9';
+    const VER                 = '1.1.8';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -211,14 +211,15 @@ final class Taxnexcy_FF_PDF_Attach {
                 }
 
                 if ( $method ) {
-                    $params = $method->getNumberOfParameters();
+                    $params   = $method->getNumberOfParameters();
+                    $settings = $this->prepare_pdf_settings( $form_id, $entry_id, $dest );
 
                     if ( $params >= 4 ) {
                         // ($entryId, $formId, $filePath, $settings)
-                        $pdf_info = $method->invoke( $ref->newInstance(), (int) $entry_id, (int) $form_id, $dest, [] );
+                        $pdf_info = $method->invoke( $ref->newInstance(), (int) $entry_id, (int) $form_id, $dest, $settings );
                     } elseif ( $params === 3 ) {
                         // ($entryId, $filePath, $settings)
-                        $pdf_info = $method->invoke( $ref->newInstance(), (int) $entry_id, $dest, [] );
+                        $pdf_info = $method->invoke( $ref->newInstance(), (int) $entry_id, $dest, $settings );
                     } elseif ( $params === 2 ) {
                         // ($entryId, $filePath)
                         $pdf_info = $method->invoke( $ref->newInstance(), (int) $entry_id, $dest );
@@ -273,7 +274,7 @@ final class Taxnexcy_FF_PDF_Attach {
                         } ],
                         [ 'generatePdf', function() use ( $inst, $form_id, $entry_id, $dest ) {
                             if ( method_exists( $inst, 'generatePdf' ) ) {
-                                return $inst->generatePdf( (int) $form_id, (int) $entry_id, [] );
+                                return $inst->generatePdf( (int) $form_id, (int) $entry_id, $this->prepare_pdf_settings( $form_id, $entry_id, $dest ) );
                             }
                             return false;
                         } ],
@@ -323,30 +324,29 @@ final class Taxnexcy_FF_PDF_Attach {
                     ->first();
 
                 if ( $form ) {
-                    $tpl = new \FluentFormPdf\Classes\Templates\GeneralTemplate( $app );
+                    $tpl      = new \FluentFormPdf\Classes\Templates\GeneralTemplate( $app );
 
-                    $feed = wpFluent()->table( 'fluentform_pdf_forms' )
-                        ->where( 'form_id', (int) $form_id )
-                        ->first();
+                    $settings = $tpl->getDefaultSettings( $form );
+                    $custom   = $this->prepare_pdf_settings( $form_id, $entry_id, $dest );
+                    $settings = array_merge( $settings, $custom );
+                    $settings = $this->replace_dynamic_tags( $settings, $form_id, $entry_id );
 
-                    if ( $feed ) {
-                        $feed = (array) $feed;
-                        if ( isset( $feed['settings'] ) && is_string( $feed['settings'] ) ) {
-                            $feed['settings'] = json_decode( $feed['settings'], true );
-                        }
+                    $feed = [
+                        'id'           => 0,
+                        'name'         => 'form-' . (int) $form_id,
+                        'template_key' => 'general',
+                        'settings'     => $settings,
+                    ];
 
-                        $tmp = $tpl->outputPDF( (int) $entry_id, $feed, $base_name, true );
+                    $tmp = $tpl->outputPDF( (int) $entry_id, $feed, $base_name, true );
 
-                        if ( $tmp && file_exists( $tmp ) ) {
-                            copy( $tmp, $dest );
-                            $this->log( 'GeneralTemplate generated file', [ 'file' => $dest ] );
-                            return $dest;
-                        }
-
-                        $this->log( 'GeneralTemplate outputPDF returned invalid path', [ 'file' => $tmp ] );
-                    } else {
-                        $this->log( 'No PDF feed found for form', [ 'form_id' => $form_id ] );
+                    if ( $tmp && file_exists( $tmp ) ) {
+                        copy( $tmp, $dest );
+                        $this->log( 'GeneralTemplate generated file', [ 'file' => $dest ] );
+                        return $dest;
                     }
+
+                    $this->log( 'GeneralTemplate outputPDF returned invalid path', [ 'file' => $tmp ] );
                 } else {
                     $this->log( 'GeneralTemplate could not find form', [ 'form_id' => $form_id ] );
                 }
@@ -457,6 +457,44 @@ final class Taxnexcy_FF_PDF_Attach {
         } else {
             echo '<p><strong>Fluent Forms PDF:</strong> File not found at ' . esc_html( $pdf ) . '</p>';
         }
+    }
+
+    /**
+     * Build settings for PDF generation with landscape orientation and colours.
+     */
+    private function prepare_pdf_settings( $form_id, $entry_id, $dest ) {
+        $settings = [
+            'file_name'     => basename( $dest ),
+            'file_path'     => $dest,
+            'save_to'       => dirname( $dest ),
+            'paper_size'    => 'A4',
+            'orientation'   => 'landscape',
+            'primary_color' => '#078586',
+            'text_color'    => '#000000',
+            'header_title'  => 'Taxnex TaxisNet Submission for {inputs.names.first_name} {inputs.names.last_name}',
+            'title'         => 'Taxnex TaxisNet Submission for {inputs.names.first_name} {inputs.names.last_name}',
+            'header_text'   => 'Taxnex TaxisNet Submission for {inputs.names.first_name} {inputs.names.last_name}',
+            // Explicit title fields for various PDF engines
+            'pdf_title'     => 'Taxnex TaxisNet Submission for {inputs.names.first_name} {inputs.names.last_name}',
+            'show_title'    => true,
+            // Basic CSS variables so colour settings are honoured
+            'css'           => ':root{--ff-primary-color:#078586;--ff-text-color:#000000;}',
+        ];
+
+        $logo = $this->get_divi_logo_url();
+        if ( $logo ) {
+            $settings['logo'] = $logo;
+        }
+        // Load a custom template if available so styling changes take effect.
+        $template_path = plugin_dir_path( __FILE__ ) . 'public/pdf-template.html';
+        if ( file_exists( $template_path ) ) {
+            $settings['template_key']   = 'custom';
+            $settings['template']       = 'custom';
+            $settings['use_custom_html'] = true;
+            $settings['custom_html']    = file_get_contents( $template_path );
+        }
+
+        return $this->replace_dynamic_tags( $settings, $form_id, $entry_id );
     }
 
     /**

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.77
+* Version:           1.7.78
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.77' );
+define( 'TAXNEXCY_VERSION', '1.7.78' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- revert PDF settings update that changed PDF feed implementation
- bump plugin version to 1.7.78

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_6896f9579a688327b345f49d016eaff5