### PR TITLE
Use General feed for PDFs and rely on FluentForms settings

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.78
+Stable tag: 1.7.79
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.79 =
+* Remove hardcoded PDF logo and template overrides so feed settings apply.
+* Use the "General" feed when generating PDFs.
+* Bump PDF helper to version 1.1.9.
 = 1.7.76 =
 * Ensure custom PDF template is used via TemplateManager settings.
 * Bump PDF helper to version 1.1.8.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.78
+Stable tag: 1.7.79
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -22,6 +22,10 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.79 =
+* Remove hardcoded PDF logo and template overrides so feed settings apply.
+* Use the "General" feed when generating PDFs.
+* Bump PDF helper to version 1.1.9.
 = 1.7.76 =
 * Ensure custom PDF template is used via TemplateManager settings.
 * Bump PDF helper to version 1.1.8.

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.8';
+    const VER                 = '1.1.9';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -333,10 +333,16 @@ final class Taxnexcy_FF_PDF_Attach {
 
                     $feed = [
                         'id'           => 0,
-                        'name'         => 'form-' . (int) $form_id,
-                        'template_key' => 'general',
+                        'name'         => 'General', // Feed name
+                        'template_key' => 'general', // Feed slug
                         'settings'     => $settings,
                     ];
+
+                    $this->log( 'Using PDF feed', [
+                        'form_id'      => $form_id,
+                        'feed_name'    => 'General',
+                        'template_key' => 'general',
+                    ] );
 
                     $tmp = $tpl->outputPDF( (int) $entry_id, $feed, $base_name, true );
 
@@ -481,40 +487,7 @@ final class Taxnexcy_FF_PDF_Attach {
             'css'           => ':root{--ff-primary-color:#078586;--ff-text-color:#000000;}',
         ];
 
-        $logo = $this->get_divi_logo_url();
-        if ( $logo ) {
-            $settings['logo'] = $logo;
-        }
-        // Load a custom template if available so styling changes take effect.
-        $template_path = plugin_dir_path( __FILE__ ) . 'public/pdf-template.html';
-        if ( file_exists( $template_path ) ) {
-            $settings['template_key']   = 'custom';
-            $settings['template']       = 'custom';
-            $settings['use_custom_html'] = true;
-            $settings['custom_html']    = file_get_contents( $template_path );
-        }
-
         return $this->replace_dynamic_tags( $settings, $form_id, $entry_id );
-    }
-
-    /**
-     * Retrieve the logo URL from Divi theme settings or fallback to the site logo.
-     */
-    private function get_divi_logo_url() {
-        $logo    = '';
-        $options = get_option( 'et_divi' );
-        if ( is_array( $options ) && ! empty( $options['logo'] ) ) {
-            $logo = esc_url( $options['logo'] );
-        }
-
-        if ( ! $logo ) {
-            $logo_id = get_theme_mod( 'custom_logo' );
-            if ( $logo_id && function_exists( 'wp_get_attachment_image_url' ) ) {
-                $logo = wp_get_attachment_image_url( $logo_id, 'full' );
-            }
-        }
-
-        return $logo;
     }
 
     /**

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.78
+* Version:           1.7.79
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.78' );
+define( 'TAXNEXCY_VERSION', '1.7.79' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- rely on Fluent Forms feed settings for PDF logo and template
- explicitly use the "General" feed when generating PDFs
- bump plugin version to 1.7.79 and PDF helper to 1.1.9

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_6897098d1be883278811c3bcb19859e9