### PR TITLE
Fix PDF feed lookup and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.79
+Stable tag: 1.7.80
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.80 =
+* Load PDF feed settings from `fluentform_form_meta` table to avoid missing table errors.
+* Bump PDF helper to version 1.1.11.
 = 1.7.79 =
 * Remove hardcoded PDF logo and template overrides so feed settings apply.
 * Use the "General" feed when generating PDFs.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.79
+Stable tag: 1.7.80
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -18,10 +18,12 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 2. Activate the plugin through the 'Plugins' menu in WordPress.
 
 == Automatic Updates ==
-Taxnex Cyprus checks for updates on its public GitHub repository, so no
-authentication token is required.
+Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.80 =
+* Load PDF feed settings from `fluentform_form_meta` table to avoid missing table errors.
+* Bump PDF helper to version 1.1.11.
 = 1.7.79 =
 * Remove hardcoded PDF logo and template overrides so feed settings apply.
 * Use the "General" feed when generating PDFs.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.79
+* Version:           1.7.80
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.79' );
+define( 'TAXNEXCY_VERSION', '1.7.80' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Load PDF feed from `fluentform_form_meta` to avoid missing table errors
- Bump plugin to version 1.7.80 and PDF helper to 1.1.11

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_689719f0862c8327a9cbd48b0d35471c