### PR TITLE
Fix PDF template key usage and bump version

### DIFF
--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.11';
+    const VER                 = '1.1.12';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -367,10 +367,14 @@ final class Taxnexcy_FF_PDF_Attach {
                         $settings = $decoded['settings'] ?? $decoded;
                         $settings = $this->replace_dynamic_tags( $settings, $form_id, $entry_id );
 
+                        // Determine template slug from multiple possible keys and expose it consistently
+                        $template_key = $feedRow->template_key ?? ( $decoded['template_key'] ?? ( $decoded['template'] ?? 'general' ) );
+
                         $feed = [
                             'id'           => (int) ( $feedRow->id ?? self::PDF_FEED_ID ),
                             'name'         => $feedRow->title        ?? ( $decoded['title'] ?? 'General' ),
-                            'template_key' => $feedRow->template_key ?? ( $decoded['template_key'] ?? 'general' ),
+                            'template'     => $template_key,
+                            'template_key' => $template_key,
                             'settings'     => $settings,
                         ];
 
@@ -391,6 +395,7 @@ final class Taxnexcy_FF_PDF_Attach {
                         $feed = [
                             'id'           => 0,
                             'name'         => 'General',
+                            'template'     => 'general',
                             'template_key' => 'general',
                             'settings'     => $settings,
                         ];

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.80
+* Version:           1.7.81
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.80' );
+define( 'TAXNEXCY_VERSION', '1.7.81' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Ensure Fluent Forms PDF feed template is respected by setting both `template` and `template_key`
- Bump PDF helper and main plugin versions

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_68971d569d88832785f4b23b11fbbace