### PR TITLE
Resolve PDF label smartcodes and include order ID in filenames

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.80
+Stable tag: 1.7.82
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.82 =
+* Replace smartcodes in form labels so user and dynamic values appear in PDFs.
+* Append WooCommerce order IDs to generated PDF filenames.
 = 1.7.80 =
 * Load PDF feed settings from `fluentform_form_meta` table to avoid missing table errors.
 * Bump PDF helper to version 1.1.11.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.80
+Stable tag: 1.7.82
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.82 =
+* Replace smartcodes in form labels so user and dynamic values appear in PDFs.
+* Append WooCommerce order IDs to generated PDF filenames.
 = 1.7.80 =
 * Load PDF feed settings from `fluentform_form_meta` table to avoid missing table errors.
 * Bump PDF helper to version 1.1.11.

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -165,7 +165,9 @@ final class Taxnexcy_FF_PDF_Attach {
         $base_name = 'taxnex-taxisnet-submission-{inputs.names.first_name}';
         $base_name = $this->replace_dynamic_tags( $base_name, $form_id, $entry_id );
         $base_name = sanitize_file_name( $base_name );
-        if ( ! $base_name ) {
+        if ( $base_name ) {
+            $base_name .= '-' . (int) $order_id;
+        } else {
             $base_name = sprintf( 'order-%d-form-%d-entry-%d', (int) $order_id, (int) $form_id, (int) $entry_id );
         }
         $filename = $base_name . '.pdf';
@@ -630,6 +632,31 @@ final class Taxnexcy_FF_PDF_Attach {
                     $replacements[ '{user.' . $key . '}' ]   = $val;
                     $replacements[ '{{user.' . $key . '}}' ] = $val;
                 }
+            }
+        }
+
+        // Fallback to form fields if user data is missing.
+        if ( ! isset( $replacements['{user.first_name}'] ) ) {
+            $first = $flat['names.first_name'] ?? $flat['first_name'] ?? '';
+            if ( $first !== '' ) {
+                $replacements['{user.first_name}']   = $first;
+                $replacements['{{user.first_name}}'] = $first;
+            }
+        }
+        if ( ! isset( $replacements['{user.last_name}'] ) ) {
+            $last = $flat['names.last_name'] ?? $flat['last_name'] ?? '';
+            if ( $last !== '' ) {
+                $replacements['{user.last_name}']   = $last;
+                $replacements['{{user.last_name}}'] = $last;
+            }
+        }
+        if ( ! isset( $replacements['{user.display_name}'] ) ) {
+            $first = $replacements['{user.first_name}'] ?? '';
+            $last  = $replacements['{user.last_name}'] ?? '';
+            $disp  = trim( $first . ' ' . $last );
+            if ( $disp !== '' ) {
+                $replacements['{user.display_name}']   = $disp;
+                $replacements['{{user.display_name}}'] = $disp;
             }
         }
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.81
+* Version:           1.7.82
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.81' );
+define( 'TAXNEXCY_VERSION', '1.7.82' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- append WooCommerce order ID to generated PDF filenames
- fallback to form field data for missing user tags so labels render actual values
- bump version to 1.7.82 and document changes

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_689721811e2483279862129cf8454d71