### PR TITLE
Replace smartcodes in stored field labels

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.82
+Stable tag: 1.7.83
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.83 =
+* Replace smartcodes in stored field labels with submitted values.
 = 1.7.82 =
 * Replace smartcodes in form labels so user and dynamic values appear in PDFs.
 * Append WooCommerce order IDs to generated PDF filenames.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.82
+Stable tag: 1.7.83
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.83 =
+* Replace smartcodes in stored field labels with submitted values.
 = 1.7.82 =
 * Replace smartcodes in form labels so user and dynamic values appear in PDFs.
 * Append WooCommerce order IDs to generated PDF filenames.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.82
+* Version:           1.7.83
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.82' );
+define( 'TAXNEXCY_VERSION', '1.7.83' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- replace smartcodes in stored field labels with submitted values
- bump plugin version to 1.7.83

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_68972692e80883278e91efdbc3ab9ab5