### PR TITLE
Append values to form labels and log enriched submission data

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.83
+Stable tag: 1.7.84
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.84 =
+* Append submitted values to stored field labels and log the updated structure.
+
 = 1.7.83 =
 * Replace smartcodes in stored field labels with submitted values.
 = 1.7.82 =

--- a/includes/class-taxnexcy-fluentforms.php
+++ b/includes/class-taxnexcy-fluentforms.php
@@ -249,10 +249,13 @@ class Taxnexcy_FluentForms {
             $field_label  = is_array( $field_labels ) ? ( $field_labels['__label'] ?? ucwords( str_replace( '_', ' ', $sanitized_key ) ) ) : ( $field_labels ?: ucwords( str_replace( '_', ' ', $sanitized_key ) ) );
             $field_label  = $this->replace_label_smartcodes( $field_label, $form_data );
 
+            $field_value  = is_array( $value ) ? wp_json_encode( $value ) : sanitize_text_field( $value );
+            $field_label .= ': ' . $field_value;
+
             $legacy_fields[] = array(
                 'slug'  => $sanitized_key,
                 'label' => $field_label,
-                'value' => is_array( $value ) ? wp_json_encode( $value ) : sanitize_text_field( $value ),
+                'value' => $field_value,
             );
         }
 
@@ -262,6 +265,7 @@ class Taxnexcy_FluentForms {
             WC()->session->set( '_ff_entry_id', absint( $entry_id ) );
             WC()->session->set( '_ff_entry_html', $this->render_entry_html( $form['id'], $entry_id ) );
             Taxnexcy_Logger::log( 'Stored fields in session: ' . wp_json_encode( $legacy_fields ) );
+            Taxnexcy_Logger::log( 'Updated submission fields: ' . wp_json_encode( $legacy_fields ) );
         }
     }
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.83
+Stable tag: 1.7.84
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.84 =
+* Append submitted values to stored field labels and log the updated structure.
+
 = 1.7.83 =
 * Replace smartcodes in stored field labels with submitted values.
 = 1.7.82 =

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.12';
+    const VER                 = '1.1.13';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.83
+* Version:           1.7.84
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.83' );
+define( 'TAXNEXCY_VERSION', '1.7.84' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Append submitted values to field labels and store them in session
- Log enriched form fields for easier debugging
- Bump plugin and PDF helper versions to 1.7.84 / 1.1.13

## Testing
- `php -l includes/class-taxnexcy-fluentforms.php`
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_68972aca0e9c8327ad64184a2c285a9e