### PR TITLE
Include field values in PDF and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.84
+Stable tag: 1.7.85
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.85 =
+* Include submitted values in generated PDFs and bump helper version.
+
 = 1.7.84 =
 * Append submitted values to stored field labels and log the updated structure.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.84
+Stable tag: 1.7.85
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.85 =
+* Include submitted values in generated PDFs and bump helper version.
+
 = 1.7.84 =
 * Append submitted values to stored field labels and log the updated structure.
 

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 final class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.1.13';
+    const VER                 = '1.1.14';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -670,6 +670,18 @@ final class Taxnexcy_FF_PDF_Attach {
             array_walk_recursive( $data, $apply );
         } else {
             $apply( $data );
+        }
+
+        if ( is_string( $data ) ) {
+            $data = preg_replace_callback(
+                '/<th([^>]*)>(.*?)<\/th>\s*<td([^>]*)>(.*?)<\/td>/s',
+                function ( $m ) {
+                    $label = trim( $m[2] );
+                    $value = trim( $m[4] );
+                    return '<th' . $m[1] . '>' . $label . ': ' . $value . '</th><td' . $m[3] . '>' . $value . '</td>';
+                },
+                $data
+            );
         }
 
         return $data;

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.84
+* Version:           1.7.85
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.84' );
+define( 'TAXNEXCY_VERSION', '1.7.85' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Append field values to their labels in generated PDFs
- Bump plugin to version 1.7.85 and PDF helper to 1.1.14
- Update readme files for new release

## Testing
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_68972d9407788327aa4348173b23c4c0