### PR TITLE
Restore Fluent Forms PDF generation and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.86
+Stable tag: 1.7.88
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,13 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.88 =
+* Restore PDF generation after upstream class name changes.
+
+= 1.7.87 =
+* Use Fluent Forms' default entry HTML output.
+* Replace smartcodes inside rendered labels with submitted values.
+
 = 1.7.86 =
 * Replace smartcodes within PDF body so {all_data} labels show submitted values.
 * Bump helper to version 1.1.15.

--- a/includes/class-gn-smartcode-pdf-template.php
+++ b/includes/class-gn-smartcode-pdf-template.php
@@ -10,7 +10,17 @@ use FluentForm\Framework\Foundation\Application;
 
 if ( ! class_exists( 'Taxnexcy_GN_Smartcode_Pdf_Template' ) ) :
 
-class Taxnexcy_GN_Smartcode_Pdf_Template extends \FluentFormPdf\Classes\Templates\TemplateManager
+if ( class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' ) ) {
+    class Taxnexcy_Pdf_Template_Base extends \FluentFormPdf\Classes\Templates\TemplateManager {}
+} elseif ( class_exists( '\FluentForm\App\Services\Pdf\Templates\TemplateManager' ) ) {
+    class Taxnexcy_Pdf_Template_Base extends \FluentForm\App\Services\Pdf\Templates\TemplateManager {}
+} elseif ( class_exists( '\FluentForm\App\Services\PDF\Templates\TemplateManager' ) ) {
+    class Taxnexcy_Pdf_Template_Base extends \FluentForm\App\Services\PDF\Templates\TemplateManager {}
+} else {
+    class Taxnexcy_Pdf_Template_Base {}
+}
+
+class Taxnexcy_GN_Smartcode_Pdf_Template extends Taxnexcy_Pdf_Template_Base
 {
     public function __construct(Application $app) { parent::__construct($app); }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.87
+Stable tag: 1.7.88
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.88 =
+* Restore PDF generation after upstream class name changes.
+
 = 1.7.87 =
 * Use Fluent Forms' default entry HTML output.
 * Replace smartcodes inside rendered labels with submitted values.

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.2.0';
+    const VER                 = '1.2.1';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -30,7 +30,10 @@ class Taxnexcy_FF_PDF_Attach {
 
         if ( ! class_exists( 'WooCommerce' ) ) return;
         if ( ! defined('FLUENTFORM') ) return;
-        if ( ! class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' ) ) return;
+        $has_manager = class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' )
+            || class_exists( '\FluentForm\App\Services\Pdf\Templates\TemplateManager' )
+            || class_exists( '\FluentForm\App\Services\PDF\Templates\TemplateManager' );
+        if ( ! $has_manager ) return;
 
         // Register our custom PDF template in the PDF add-on (if active)
         add_action('fluentform/loaded', function () {
@@ -110,7 +113,10 @@ class Taxnexcy_FF_PDF_Attach {
     }
 
     private function generate_via_custom_template( $form_id, $entry_id, $dest ) {
-        if ( ! class_exists('\\FluentFormPdf\\Classes\\Templates\\GeneralTemplate') || ! function_exists('wpFluent') ) {
+        $has_template = class_exists('\\FluentFormPdf\\Classes\\Templates\\GeneralTemplate')
+            || class_exists('\\FluentForm\\App\\Services\\Pdf\\Templates\\GeneralTemplate')
+            || class_exists('\\FluentForm\\App\\Services\\PDF\\Templates\\GeneralTemplate');
+        if ( ! $has_template || ! function_exists('wpFluent') ) {
             return false;
         }
         if ( ! class_exists('\\Taxnexcy_GN_Smartcode_Pdf_Template') ) {

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.87
+* Version:           1.7.88
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.87' );
+define( 'TAXNEXCY_VERSION', '1.7.88' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- adapt PDF helper to new Fluent Forms PDF class namespaces
- extend custom PDF template to support multiple TemplateManager locations
- bump plugin version to 1.7.88 and update docs

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`
- `php -l includes/class-gn-smartcode-pdf-template.php`


------
https://chatgpt.com/codex/tasks/task_e_689743f26fec8327a552e757dcd02be8