### PR TITLE
Revert PDF changes and bump plugin version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.88
+Stable tag: 1.7.89
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,12 +23,8 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
-= 1.7.88 =
-* Restore PDF generation after upstream class name changes.
-
-= 1.7.87 =
-* Use Fluent Forms' default entry HTML output.
-* Replace smartcodes inside rendered labels with submitted values.
+= 1.7.89 =
+* Revert to previous stable release.
 
 = 1.7.86 =
 * Replace smartcodes within PDF body so {all_data} labels show submitted values.

--- a/includes/class-gn-smartcode-pdf-template.php
+++ b/includes/class-gn-smartcode-pdf-template.php
@@ -10,17 +10,7 @@ use FluentForm\Framework\Foundation\Application;
 
 if ( ! class_exists( 'Taxnexcy_GN_Smartcode_Pdf_Template' ) ) :
 
-if ( class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' ) ) {
-    class Taxnexcy_Pdf_Template_Base extends \FluentFormPdf\Classes\Templates\TemplateManager {}
-} elseif ( class_exists( '\FluentForm\App\Services\Pdf\Templates\TemplateManager' ) ) {
-    class Taxnexcy_Pdf_Template_Base extends \FluentForm\App\Services\Pdf\Templates\TemplateManager {}
-} elseif ( class_exists( '\FluentForm\App\Services\PDF\Templates\TemplateManager' ) ) {
-    class Taxnexcy_Pdf_Template_Base extends \FluentForm\App\Services\PDF\Templates\TemplateManager {}
-} else {
-    class Taxnexcy_Pdf_Template_Base {}
-}
-
-class Taxnexcy_GN_Smartcode_Pdf_Template extends Taxnexcy_Pdf_Template_Base
+class Taxnexcy_GN_Smartcode_Pdf_Template extends \FluentFormPdf\Classes\Templates\TemplateManager
 {
     public function __construct(Application $app) { parent::__construct($app); }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.88
+Stable tag: 1.7.89
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,8 +21,8 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
-= 1.7.88 =
-* Restore PDF generation after upstream class name changes.
+= 1.7.89 =
+* Revert to previous stable release.
 
 = 1.7.87 =
 * Use Fluent Forms' default entry HTML output.

--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'Taxnexcy_FF_PDF_Attach' ) ) :
 
 class Taxnexcy_FF_PDF_Attach {
 
-    const VER                 = '1.2.1';
+    const VER                 = '1.2.0';
     const SESSION_KEY         = 'taxnexcy_ff_entry_map';
     const ORDER_META_PDF_PATH = '_ff_entry_pdf';
     const LOG_FILE            = 'taxnexcy-ffpdf.log';
@@ -30,10 +30,7 @@ class Taxnexcy_FF_PDF_Attach {
 
         if ( ! class_exists( 'WooCommerce' ) ) return;
         if ( ! defined('FLUENTFORM') ) return;
-        $has_manager = class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' )
-            || class_exists( '\FluentForm\App\Services\Pdf\Templates\TemplateManager' )
-            || class_exists( '\FluentForm\App\Services\PDF\Templates\TemplateManager' );
-        if ( ! $has_manager ) return;
+        if ( ! class_exists( '\FluentFormPdf\Classes\Templates\TemplateManager' ) ) return;
 
         // Register our custom PDF template in the PDF add-on (if active)
         add_action('fluentform/loaded', function () {
@@ -113,10 +110,7 @@ class Taxnexcy_FF_PDF_Attach {
     }
 
     private function generate_via_custom_template( $form_id, $entry_id, $dest ) {
-        $has_template = class_exists('\\FluentFormPdf\\Classes\\Templates\\GeneralTemplate')
-            || class_exists('\\FluentForm\\App\\Services\\Pdf\\Templates\\GeneralTemplate')
-            || class_exists('\\FluentForm\\App\\Services\\PDF\\Templates\\GeneralTemplate');
-        if ( ! $has_template || ! function_exists('wpFluent') ) {
+        if ( ! class_exists('\\FluentFormPdf\\Classes\\Templates\\GeneralTemplate') || ! function_exists('wpFluent') ) {
             return false;
         }
         if ( ! class_exists('\\Taxnexcy_GN_Smartcode_Pdf_Template') ) {

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.88
+* Version:           1.7.89
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.88' );
+define( 'TAXNEXCY_VERSION', '1.7.89' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- revert PDF generation changes
- bump plugin version to 1.7.89

## Testing
- `php -l taxnexcy.php`
- `php -l includes/class-gn-smartcode-pdf-template.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_68974bbcc2fc8327970de8b5c309c030