### PR TITLE
Mirror logger output to error log and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.95
+Stable tag: 1.7.96
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.96 =
+* Mirror log entries to the PHP error log for easier debugging.
+
 = 1.7.91 =
 * Replace dynamic tokens in PDF HTML output so labels show submitted values.
 * Bump PDF helper to version 1.1.13.

--- a/includes/class-taxnexcy-logger.php
+++ b/includes/class-taxnexcy-logger.php
@@ -14,8 +14,15 @@ class Taxnexcy_Logger {
      * @param string $message Message to log.
      */
     public static function log( $message ) {
+        $line = current_time( 'mysql' ) . ' - ' . $message;
+
+        // Mirror log entries to the PHP error log when debugging is enabled.
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( $line );
+        }
+
         $logs   = get_option( self::OPTION_KEY, array() );
-        $logs[] = current_time( 'mysql' ) . ' - ' . $message;
+        $logs[] = $line;
         update_option( self::OPTION_KEY, $logs );
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.95
+Stable tag: 1.7.96
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.96 =
+* Mirror log entries to the PHP error log for easier debugging.
+
 = 1.7.91 =
 * Replace dynamic tokens in PDF HTML output so labels show submitted values.
 * Bump PDF helper to version 1.1.13.

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
- * Version:           1.7.95
+* Version:           1.7.96
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.95' );
+define( 'TAXNEXCY_VERSION', '1.7.96' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Log messages mirror to the PHP error log when debugging, ensuring visibility.
- Bump plugin version to 1.7.96 and update documentation.

## Testing
- `php -l includes/class-taxnexcy-logger.php`
- `php -l taxnexcy.php`


------
https://chatgpt.com/codex/tasks/task_e_68977255eac08327a79d3b5eaf19d01c