### PR TITLE
Add admin logging and bump version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.97
+Stable tag: 1.7.98
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,9 @@ Taxnex Cyprus checks for updates on its public GitHub repository, so no
 authentication token is required.
 
 == Changelog ==
+= 1.7.98 =
+* Add comments and verbose admin logging.
+
 = 1.7.97 =
 * Revert plugin to stable 1.7.82 code base.
 

--- a/admin/class-taxnexcy-admin.php
+++ b/admin/class-taxnexcy-admin.php
@@ -58,23 +58,25 @@ class Taxnexcy_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public function enqueue_styles() {
+        public function enqueue_styles() {
+                /**
+                 * This function is provided for demonstration purposes only.
+                 *
+                 * An instance of this class should be passed to the run() function
+                 * defined in Taxnexcy_Loader as all of the hooks are defined
+                 * in that particular class.
+                 *
+                 * The Taxnexcy_Loader will then create the relationship
+                 * between the defined hooks and the functions defined in this
+                 * class.
+                 */
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Taxnexcy_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Taxnexcy_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
+                // Log that admin styles are being enqueued for easier debugging.
+                Taxnexcy_Logger::log( 'Enqueuing admin styles' );
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/taxnexcy-admin.css', array(), $this->version, 'all' );
+                wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/taxnexcy-admin.css', array(), $this->version, 'all' );
 
-	}
+        }
 
 	/**
 	 * Register the JavaScript for the admin area.
@@ -82,18 +84,20 @@ class Taxnexcy_Admin {
 	 * @since    1.0.0
 	 */
         public function enqueue_scripts() {
+                /**
+                 * This function is provided for demonstration purposes only.
+                 *
+                 * An instance of this class should be passed to the run() function
+                 * defined in Taxnexcy_Loader as all of the hooks are defined
+                 * in that particular class.
+                 *
+                 * The Taxnexcy_Loader will then create the relationship
+                 * between the defined hooks and the functions defined in this
+                 * class.
+                 */
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in Taxnexcy_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The Taxnexcy_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
+                // Log that admin scripts are being enqueued.
+                Taxnexcy_Logger::log( 'Enqueuing admin scripts' );
 
                 wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/taxnexcy-admin.js', array( 'jquery' ), $this->version, false );
 
@@ -103,7 +107,9 @@ class Taxnexcy_Admin {
          * Enqueue Fluent Forms admin CSS on order screens.
          */
         public function enqueue_ff_admin_css() {
+                // Only enqueue on WooCommerce order screens.
                 if ( 'shop_order' === ( get_current_screen()->id ?? '' ) ) {
+                        Taxnexcy_Logger::log( 'Enqueuing Fluent Forms admin CSS on order screen' );
                         wp_enqueue_style(
                                 'fluent-forms-admin',
                                 FLUENTFORM_PLUGIN_URL . 'assets/css/fluent-forms-admin.css',
@@ -117,6 +123,7 @@ class Taxnexcy_Admin {
          * Register Taxnexcy admin menu and subpages.
          */
         public function add_admin_menu() {
+                // Register the main menu page.
                 add_menu_page(
                         'Taxnexcy',
                         'Taxnexcy',
@@ -126,6 +133,7 @@ class Taxnexcy_Admin {
                         'dashicons-cart'
                 );
 
+                // Register subpages for settings and the log viewer.
                 add_submenu_page(
                         'taxnexcy',
                         'Form Product Mapping',
@@ -143,6 +151,8 @@ class Taxnexcy_Admin {
                         'taxnexcy-log',
                         array( $this, 'render_log_page' )
                 );
+
+                Taxnexcy_Logger::log( 'Admin menus registered' );
         }
 
         /**
@@ -153,7 +163,9 @@ class Taxnexcy_Admin {
                         return;
                 }
 
+                // Fetch the log lines and render them in a basic table.
                 $logs = Taxnexcy_Logger::get_logs();
+                Taxnexcy_Logger::log( 'Rendering admin log page' );
                 include plugin_dir_path( __FILE__ ) . 'partials/taxnexcy-log-page.php';
         }
 
@@ -165,6 +177,7 @@ class Taxnexcy_Admin {
                         return;
                 }
 
+                // Retrieve any existing form to product mappings from the database.
                 $mappings = get_option( TAXNEXCY_FORM_PRODUCTS_OPTION, array() );
 
                 $forms = array();
@@ -188,6 +201,7 @@ class Taxnexcy_Admin {
                         ) );
                 }
 
+                Taxnexcy_Logger::log( 'Rendering settings page' );
                 include plugin_dir_path( __FILE__ ) . 'partials/taxnexcy-settings-page.php';
         }
 
@@ -199,8 +213,13 @@ class Taxnexcy_Admin {
                         wp_die( 'Forbidden' );
                 }
 
+                // Protect against CSRF.
                 check_admin_referer( 'taxnexcy_clear_log' );
+
+                // Clear existing log entries then record the action.
                 Taxnexcy_Logger::clear();
+                Taxnexcy_Logger::log( 'Plugin log cleared', array( 'user_id' => get_current_user_id() ) );
+
                 wp_redirect( admin_url( 'admin.php?page=taxnexcy-log' ) );
                 exit;
         }
@@ -213,11 +232,13 @@ class Taxnexcy_Admin {
                         wp_die( 'Forbidden' );
                 }
 
+                // Verify intent before processing the submitted mappings.
                 check_admin_referer( 'taxnexcy_save_mappings' );
 
                 $forms    = isset( $_POST['taxnexcy_forms'] ) ? array_map( 'intval', (array) $_POST['taxnexcy_forms'] ) : array();
                 $products = isset( $_POST['taxnexcy_products'] ) ? array_map( 'intval', (array) $_POST['taxnexcy_products'] ) : array();
 
+                // Build an associative array of form ID => product ID pairs.
                 $mappings = array();
                 foreach ( $forms as $index => $form_id ) {
                         $product_id = $products[ $index ] ?? 0;
@@ -227,6 +248,8 @@ class Taxnexcy_Admin {
                 }
 
                 update_option( TAXNEXCY_FORM_PRODUCTS_OPTION, $mappings );
+
+                Taxnexcy_Logger::log( 'Saved form/product mappings', array( 'mappings' => $mappings, 'user_id' => get_current_user_id() ) );
 
                 wp_redirect( admin_url( 'admin.php?page=taxnexcy' ) );
                 exit;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://georgenicolaou.me/
 Tags: fluentforms, woocommerce, jcc
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.97
+Stable tag: 1.7.98
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ This plugin integrates FluentForms with WooCommerce to create customers and proc
 Taxnex Cyprus checks for updates on its public GitHub repository, so no authentication token is required.
 
 == Changelog ==
+= 1.7.98 =
+* Add comments and verbose admin logging.
+
 = 1.7.97 =
 * Revert plugin to stable 1.7.82 code base.
 

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.97
+* Version:           1.7.98
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.97' );
+define( 'TAXNEXCY_VERSION', '1.7.98' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- log admin asset enqueues, menu registration, and settings actions using plugin logger
- document new logging and bump plugin version to 1.7.98

## Testing
- `php -l taxnexcy.php`
- `php -l admin/class-taxnexcy-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_6898525d30bc8327b5d34230366320a9