### PR TITLE
Prevent empty smartcode replacements

### DIFF
--- a/taxnexcy-ff-pdf-attachment.php
+++ b/taxnexcy-ff-pdf-attachment.php
@@ -700,7 +700,10 @@ final class Taxnexcy_FF_PDF_Attach {
             $registered[ $code ] = true;
 
             $callback = function ( $val, $form = null ) use ( $value ) {
-                return is_scalar( $value ) ? (string) $value : '';
+                if ( is_scalar( $value ) && $value !== '' ) {
+                    return (string) $value;
+                }
+                return $val;
             };
 
             $filter = 'fluentform/shortcode_parser_callback_' . $code;
@@ -745,7 +748,7 @@ final class Taxnexcy_FF_PDF_Attach {
                     $item = preg_replace_callback(
                         '/\{\{?([^{}]+)\}?\}/',
                         function ( $matches ) use ( $form ) {
-                            return apply_filters( 'fluentform/shortcode_parser_callback_' . $matches[1], '', $form );
+                            return apply_filters( 'fluentform/shortcode_parser_callback_' . $matches[1], $matches[0], $form );
                         },
                         $item
                     );

--- a/taxnexcy.php
+++ b/taxnexcy.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Taxnex Cyprus
  * Plugin URI:        https://georgenicolaou.me/taxnexcy
 * Description:       Creates WooCommerce user from FluentForms submission
-* Version:           1.7.99
+* Version:           1.8.0
 * Author:            George Nicolaou
  * Author URI:        https://georgenicolaou.me/
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
   * Start at version 1.0.0 and use SemVer - https://semver.org
   * Rename this for your plugin and update it as you release new versions.
   */
-define( 'TAXNEXCY_VERSION', '1.7.99' );
+define( 'TAXNEXCY_VERSION', '1.8.0' );
 
 /**
  * Map Fluent Forms IDs to WooCommerce product IDs.


### PR DESCRIPTION
## Summary
- Preserve smartcode tokens if parser returns empty
- Fallback registered callbacks to original value
- Bump plugin version to 1.8.0

## Testing
- `php -l taxnexcy.php`
- `php -l taxnexcy-ff-pdf-attachment.php`


------
https://chatgpt.com/codex/tasks/task_e_6898691c1328832783585a8bfcac40a1