### PR TITLE
Support `redirectUrl` and fallback payload in form submission handler

### DIFF
--- a/public/js/taxnexcy-public.js
+++ b/public/js/taxnexcy-public.js
@@ -4,8 +4,9 @@
         // Redirect to the payment page if the form response includes a URL.
         $( document ).on( 'fluentform_submission_success', function( event, data, response ) {
             var url = '';
-            if ( response ) {
-                url = response.redirect_to || response.redirect_url || response.redirectTo;
+            var payload = response || data || {};
+            if ( payload ) {
+                url = payload.redirectUrl || payload.redirect_to || payload.redirect_url || payload.redirectTo;
             }
 
             if ( url ) {


### PR DESCRIPTION
### Motivation
- The server response uses a `redirectUrl` key to provide the payment URL rather than `redirect_to`/`redirect_url`.
- The frontend previously only checked `response.redirect_to`, `response.redirect_url`, or `response.redirectTo` and could miss the payment URL.
- In some cases the `response` argument may be empty and the URL is present on the `data` payload instead.
- When the URL was missed the core handler would fall back to the form confirmation URL instead of redirecting to the payment page.

### Description
- Update `public/js/taxnexcy-public.js` to use `var payload = response || data || {}` and read `payload.redirectUrl` first.
- Preserve legacy support by falling back to `payload.redirect_to`, `payload.redirect_url`, and `payload.redirectTo`.
- Ensure the redirect still occurs via `window.location.href = url` when a URL is found.
- Only the public form submission handler was modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e4c5595c832788788ae3b6a6e1b9)